### PR TITLE
Fix battery measurement issue

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -317,10 +317,14 @@ Adafruit_SHT4x sht4 = Adafruit_SHT4x();
 #elif defined MakerBadge_revB
 ESP32AnalogRead adc;
 #define vBatPin 9 
+#define dividerRatio 1.5
+#define BATT_V_CAL_SCALE 1.00
 
 #elif defined MakerBadge_revD
 ESP32AnalogRead adc;
 #define vBatPin 9
+#define dividerRatio 1.5
+#define BATT_V_CAL_SCALE 1.05
 
 #else
 ESP32AnalogRead adc;
@@ -388,14 +392,14 @@ uint8_t getBatteryVoltage()
 
 #elif defined MakerBadge_revB
   adc.attach(vBatPin);
-  d_volt = 2.0*(2.50*adc.readVoltage()/4096);
+  d_volt = (BATT_V_CAL_SCALE*2.0*(2.50*batt_adc/4096)); // d_volt = adc.readVoltage() * dividerRatio;
   Serial.println("Battery voltage: " + String(d_volt) + " V");
 
   return d_volt;
 
 #elif defined MakerBadge_revD
-adc.attach(vBatPin);
-  d_volt = 2*2.0*(2.50*adc.readVoltage()/4096);
+  adc.attach(vBatPin);
+  d_volt = (BATT_V_CAL_SCALE*2.0*(2.50*batt_adc/4096)); // d_volt = adc.readVoltage() * dividerRatio;
   Serial.println("Battery voltage: " + String(d_volt) + " V");
 
   return d_volt;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -119,6 +119,7 @@ esp_adc_cal_characteristics_t adc_cal;
 #define PIN_RST 39 // RES
 #define PIN_BUSY 42 // PIN_BUSY
 #define ePaperPowerPin 16 // only version D and newer supports this feature
+#define enableBattery 14
 #endif
 
 //#define REMAP_SPI
@@ -321,6 +322,7 @@ ESP32AnalogRead adc;
 #define BATT_V_CAL_SCALE 1.00
 
 #elif defined MakerBadge_revD
+digitalWrite(enableBattery, LOW);
 ESP32AnalogRead adc;
 #define vBatPin 9
 #define dividerRatio 1.5


### PR DESCRIPTION
It's a work in progress, but it's getting somewhere. There are currently two ways to do the battery measurement. Using the library or calculating voltage from the raw data. Both ways are written in the code now, but neither of them works. 

It's also a fix for the issue with version D of having to pull the pin low to even just measure something.

Also fixed missing space. 