### PR TITLE
Fix random read issues

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -506,6 +506,28 @@ uint32_t read8n(WiFiClient& client, uint8_t *buffer, int32_t bytes)
 }
 
 uint32_t skip(WiFiClient& client, int32_t bytes)
+// read one byte safely from WiFiClient, wait a while if data are not available immediately
+uint8_t safe_read(WiFiClient& client)
+{
+  int32_t remain = 1;
+  uint32_t start = millis();
+
+  uint8_t ret;
+  while ((client.connected() || client.available()) && (remain > 0))
+  {
+    if (client.available())
+    {
+      int16_t v = client.read();
+      ret = uint8_t(v);
+      remain--;
+    }
+    else delay(1);
+    if (millis() - start > 2000) break; // don't hang forever
+  }
+  return ret;
+}
+
+uint32_t read8n(WiFiClient& client, uint8_t* buffer, int32_t bytes)
 {
   return read8n(client, NULL, bytes);
 }
@@ -514,8 +536,8 @@ uint16_t read16(WiFiClient& client)
 {
   // BMP data is stored little-endian, same as Arduino.
   uint16_t result;
-  ((uint8_t *)&result)[0] = client.read(); // LSB
-  ((uint8_t *)&result)[1] = client.read(); // MSB
+  ((uint8_t *)&result)[0] = safe_read(client); // LSB
+  ((uint8_t *)&result)[1] = safe_read(client); // MSB
   return result;
 }
 
@@ -523,10 +545,10 @@ uint32_t read32(WiFiClient& client)
 {
   // BMP data is stored little-endian, same as Arduino.
   uint32_t result;
-  ((uint8_t *)&result)[0] = client.read(); // LSB
-  ((uint8_t *)&result)[1] = client.read();
-  ((uint8_t *)&result)[2] = client.read();
-  ((uint8_t *)&result)[3] = client.read(); // MSB
+  ((uint8_t *)&result)[0] = safe_read(client); // LSB
+  ((uint8_t *)&result)[1] = safe_read(client);
+  ((uint8_t *)&result)[2] = safe_read(client);
+  ((uint8_t *)&result)[3] = safe_read(client); // MSB
   return result;
 }
 
@@ -824,10 +846,10 @@ void readBitmapData()
           bytes_read += skip(client, (int32_t)(imageOffset - (4 << depth) - bytes_read)); // 54 for regular, diff for colorsimportant
           for (uint16_t pn = 0; pn < (1 << depth); pn++)
           {
-            blue = client.read();
-            green = client.read();
-            red = client.read();
-            client.read();
+            blue  = safe_read(client);
+            green = safe_read(client);
+            red   = safe_read(client);
+            skip(client, 1);
             bytes_read += 4;
             whitish = with_color ? ((red > 0x80) && (green > 0x80) && (blue > 0x80)) : ((red + green + blue) > 3 * 0x80); // whitish
             colored = (red > 0xF0) || ((green > 0xF0) && (blue > 0xF0)); // reddish or yellowish?

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -506,30 +506,16 @@ uint32_t read8n(WiFiClient& client, uint8_t *buffer, int32_t bytes)
 }
 
 uint32_t skip(WiFiClient& client, int32_t bytes)
+{
+  return read8n(client, NULL, bytes);
+}
+
 // read one byte safely from WiFiClient, wait a while if data are not available immediately
 uint8_t safe_read(WiFiClient& client)
 {
-  int32_t remain = 1;
-  uint32_t start = millis();
-
   uint8_t ret;
-  while ((client.connected() || client.available()) && (remain > 0))
-  {
-    if (client.available())
-    {
-      int16_t v = client.read();
-      ret = uint8_t(v);
-      remain--;
-    }
-    else delay(1);
-    if (millis() - start > 2000) break; // don't hang forever
-  }
+  read8n(client, &ret, 1);
   return ret;
-}
-
-uint32_t read8n(WiFiClient& client, uint8_t* buffer, int32_t bytes)
-{
-  return read8n(client, NULL, bytes);
 }
 
 uint16_t read16(WiFiClient& client)


### PR DESCRIPTION
Fix intermittent issues caused by the raw `client.read()` call not being able to handle delays (which might be caused either by the network or server, it's not relevant for this issue). 

Whenever there is no *immediately* available data during the `read()` call it returns -1 instead of waiting for more data because the whole WiFiClient library works in nonblocking mode.
The already existing `read8n()` method takes care of this situation and calls the read() in a loop in such situation.

This fix adds a new `safe_read()` method which is just a wrapper for read8n(..., 1). This should fix any issues with intermittent glitches in the displayed content caused by the read() trying to read data sooner then they are available.

I've verified locally that this doesn't break anything, at least for 3C display 800x480 and ESPInk board.