### PR TITLE
Fix/wifi client

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -915,6 +915,7 @@ bool createHttpRequest(WiFiClient &client, bool &connStatus, bool checkTimestamp
   return true;
 }
 
+#ifdef SENSOR
 int readSensorsVal(float &sen_temp, int &sen_humi, int &sen_pres)
 {
   Wire.begin();
@@ -971,6 +972,7 @@ int readSensorsVal(float &sen_temp, int &sen_humi, int &sen_pres)
 
   return 0;
 }
+#endif
 
 bool checkForNewTimestampOnServer()
 {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -361,8 +361,6 @@ SPIClass hspi(HSPI);
   Adafruit_BME280 bme;
 #endif
 
-WiFiClient client;
-
 /* ---- ADC reading - indoor Battery voltage ---- */
 #ifdef ES3ink
   #define vBatPin ADC1_GPIO2_CHANNEL
@@ -977,6 +975,7 @@ int readSensorsVal(float &sen_temp, int &sen_humi, int &sen_pres)
 bool checkForNewTimestampOnServer()
 {
   // Connect to the HOST and read data via GET method
+  WiFiClient client; // Use WiFiClient class to create TCP connections
   bool connection_ok = false;
   String extraParams = "";
 
@@ -1017,6 +1016,7 @@ bool checkForNewTimestampOnServer()
 void readBitmapData()
 {
   // Connect to the HOST and read data via GET method
+  WiFiClient client; // Use WiFiClient class to create TCP connections
 
   // Let's read bitmap
   static const uint16_t input_buffer_pixels = 800; // may affect performance


### PR DESCRIPTION
- add missing `SENSOR` ifdef, while it wasn't possible to compile code without sensor
- do not overlap global variable with local one
  - `WifiClient client` object was overlapping with local variables with same name
  - functions have been using a reference to global object
  - ⚠️ At the end, this is very bad practice!
  - A correct solution is to create an `WifiClient` in `WiFiInit` function then re-use it from there. But this change requires some testing... .

/cc @pklosko