### PR TITLE
Feat/ci

### DIFF
--- a/.github/workflows/PIO build.yml
+++ b/.github/workflows/PIO build.yml
@@ -23,28 +23,3 @@ jobs:
 
       - name: Compile firmware binaries
         run: pio run
-      - name: Upload binaries
-        uses: actions/upload-artifact@v3
-        with:
-          path: .pio/build/*/*.bin
-          name: firmware
-  release-project:
-    name: Release project
-    runs-on: ubuntu-latest
-    outputs:
-      upload_url: ${{ steps.step_upload_url.outputs.upload_url }}
-    needs: build-project
-    steps:
-    - name: Download artifact
-      uses: actions/download-artifact@v3
-      with:
-        name: firmware
-        path: ${{ github.workspace }}
-    - name: Create Release With Asset
-      id: Release-AIO
-      uses: Hs1r1us/Release-AIO@v2.0.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{github.run_number}}
-        asset_files: /home/runner/work/zivyobraz-fw/zivyobraz-fw/

--- a/platformio.ini
+++ b/platformio.ini
@@ -11,25 +11,37 @@
 [env]
 framework = arduino
 monitor_speed = 115200
-lib_deps = 
+platform = espressif32
+lib_deps =
 	zinggjm/GxEPD2@^1.5.4
 	adafruit/Adafruit GFX Library@^1.11.9
 	madhephaestus/ESP32AnalogRead@^0.2.1
 	adafruit/Adafruit SHT4x Library@^1.0.3
 	adafruit/Adafruit BME280 Library@^2.2.4
 	sparkfun/SparkFun SCD4x Arduino Library@^1.1.2
+# first supported display
+build_flags =
+	-D TYPE_BW
+	-D D_DEPG0213BN
 custom_fw_version = 2_2
 
 [env:espink]
-platform = espressif32
 board = esp32dev
+build_flags =
+	${env.build_flags}
+	-D ESPink
+	-D SENSOR # one build with sensor
 
 [env:es3ink]
-platform = espressif32
 board = esp32-s3-devkitc-1
 board_upload.flash_size = 4MB
 board_build.partitions = default.csv
+build_flags =
+	${env.build_flags}
+	-D ES3ink
 
 [env:MakerBadge]
-platform = espressif32
 board = featheresp32-s2
+build_flags =
+	${env.build_flags}
+	-D MakerBadge_revB


### PR DESCRIPTION
- enable build for: `ESPink`, `ES3ink` and `MakerBadge_revB`
  - use dummy configuration
    - first supported display
    - with/without sensor
-  drop upload and release sections
  - both of sections are not used in this workflow  