### PR TITLE
Interpret color2/3 as black/white for TYPE_BW

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1583,7 +1583,10 @@ void readBitmapData(WiFiClient &client)
     uint16_t color2 = GxEPD_RED;
     uint16_t color3 = GxEPD_YELLOW;
 
-#if (defined TYPE_BW) || (defined TYPE_GRAYSCALE)
+#if defined TYPE_BW
+    color2 = GxEPD_BLACK;
+    color3 = GxEPD_WHITE;
+#elif defined TYPE_GRAYSCALE
     color2 = GxEPD_LIGHTGREY;
     color3 = GxEPD_DARKGREY;
 #endif


### PR DESCRIPTION
When using Z2 encoding, the color RED is not displayed correctly on BW e-paper. 

Note: I did not test this with zivyobraz.eu but rather my own server serving custom files that reimplements the z2. 