### PR TITLE
Make CI builds workig

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,60 +9,76 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [env]
+custom_fw_version = 2_2
 framework = arduino
 monitor_speed = 115200
 platform = espressif32
-lib_deps_builtin =
-	SPI
-	Wire
-lib_deps =
-	zinggjm/GxEPD2@^1.6.0
-    adafruit/Adafruit GFX Library@^1.11.9
-	madhephaestus/ESP32AnalogRead@^0.3.0
-	adafruit/Adafruit SHT4x Library@^1.0.3
-	adafruit/Adafruit BME280 Library@^2.2.4
-	sparkfun/SparkFun SCD4x Arduino Library@^1.1.2
+
+[common]
 # first supported display
-custom_fw_version = 2_2
+build_flags =
+    -D TYPE_BW
+    -D D_GDEW0154T8
+lib_deps_builtin =
+    SPI
+    Wire
+lib_deps =
+    zinggjm/GxEPD2@^1.6.0
+    adafruit/Adafruit GFX Library@^1.11.9
+    madhephaestus/ESP32AnalogRead@^0.3.0
+    adafruit/Adafruit SHT4x Library@^1.0.3
+    adafruit/Adafruit BME280 Library@^2.2.4
+    sparkfun/SparkFun SCD4x Arduino Library@^1.1.2
+lib_ignore = GxEPD2_4G
 
 [env:espink_v3]
-platform = espressif32
 board = esp32-s3-devkitc-1
 build_flags =
-	${env.build_flags}
-	-D SENSOR # one build with sensor
-    -DARDUINO_USB_MODE=1
-    -DARDUINO_USB_CDC_ON_BOOT=1
+    ${common.build_flags}
+    -D ESPink_V3
+    -D SENSOR # one build with sensor
+    -D ARDUINO_USB_MODE=1
+    -D ARDUINO_USB_CDC_ON_BOOT=1
 board_upload.flash_size = 4MB
 board_build.partitions = default.csv
-lib_ignore = GxEPD2
 lib_deps =
-	${env.lib_deps}
-	${env.lib_deps_builtin
+    ${common.lib_deps_builtin}
+    ${common.lib_deps}
+    sparkfun/SparkFun MAX1704x Fuel Gauge Arduino Library@^1.0.4
+lib_ignore = ${common.lib_ignore}
 
 [env:espink]
 board = esp32dev
 build_flags =
-	${env.build_flags}
-	-D ESPink
-	-D SENSOR # one build with sensor
+    ${common.build_flags}
+    -D ESPink_V2
+    -D SENSOR # one build with sensor
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
 
 [env:es3ink]
 board = esp32-s3-devkitc-1
 board_upload.flash_size = 4MB
 board_build.partitions = default.csv
-lib_deps =
-	${env.lib_deps}
-	${env.lib_deps_builtin}
-	adafruit/Adafruit NeoPixel@^1.12.0
 build_flags =
-	${env.build_flags}
-	-D ES3ink
-	-DARDUINO_USB_MODE=1
-   	-DARDUINO_USB_CDC_ON_BOOT=1
+    ${common.build_flags}
+    -D ES3ink
+    -D ARDUINO_USB_MODE=1
+    -D ARDUINO_USB_CDC_ON_BOOT=1
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps}
+    adafruit/Adafruit NeoPixel@^1.12.0
+lib_ignore = ${common.lib_ignore}
 
 [env:MakerBadge]
 board = featheresp32-s2
 build_flags =
-	${env.build_flags}
-	-D MakerBadge_revB
+    ${common.build_flags}
+    -D MakerBadge_revB
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -466,6 +466,7 @@ GxEPD2_7C<GxEPD2_730c_GDEP073E01, GxEPD2_730c_GDEP073E01::HEIGHT / 4> display(Gx
 // ADC reading
 #include <ESP32AnalogRead.h>
 // Font
+#include <gfxfont.h>
 //#include "fonts/OpenSansSB_12px.h"
 #include "fonts/OpenSansSB_14px.h"
 #include "fonts/OpenSansSB_16px.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -219,17 +219,17 @@
 
 // 2 colors (Black and White)
 #ifdef TYPE_BW
-  #include "GxEPD2_BW.h"
+  #include <GxEPD2_BW.h>
 static const char *defined_color_type = "BW";
 
 // 3 colors (Black, White and Red/Yellow)
 #elif defined TYPE_3C
-  #include "GxEPD2_3C.h"
+  #include <GxEPD2_3C.h>
 static const char *defined_color_type = "3C";
 
 // 4 colors (Black, White, Red and Yellow)
 #elif defined TYPE_4C
-  #include "GxEPD2_4C.h"
+  #include <GxEPD2_4C.h>
 static const char *defined_color_type = "4C";
 
 // 4 colors (Grayscale - Black, Darkgrey, Lightgrey, White) (https://github.com/ZinggJM/GxEPD2_4G)
@@ -240,7 +240,7 @@ static const char *defined_color_type = "4G";
 
 // 7 colors
 #elif defined TYPE_7C
-  #include "GxEPD2_7C.h"
+  #include <GxEPD2_7C.h>
 static const char *defined_color_type = "7C";
 #else
   #error "ePaper type not defined!"


### PR DESCRIPTION
- add missing fonts include
  - some types from `gfxfont.h` were used, but not included
- change local includes to global for external headers
- `platformio`
  - unify style
  - move build common parts into `[common]` section