### PR TITLE
CrowPanel ESP32-S3 support, add 5.79/4.2/2.13 boards

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -130,3 +130,45 @@ build_flags=
     -D SEEEDSTUDIO_XIAO_EDDB_ESP32S3
     -D D_GDEY075T7BW
 lib_ignore = ${common.lib_ignore}
+
+[env:crowpanel_esp32s3_579]
+platform = espressif32
+board = esp32-s3-devkitc-1
+board_upload.flash_size = 8MB
+board_build.partitions = default.csv
+build_flags=
+    -D TYPE_BW
+    -D CROWPANEL_ESP32S3_579
+    -D D_GDEY0579T93
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+
+[env:crowpanel_esp32s3_42]
+platform = espressif32
+board = esp32-s3-devkitc-1
+board_upload.flash_size = 8MB
+board_build.partitions = default.csv
+build_flags=
+    -D TYPE_BW
+    -D CROWPANEL_ESP32S3_42
+    -D D_GDEQ042T81
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}
+
+[env:crowpanel_esp32s3_213]
+platform = espressif32
+board = esp32-s3-devkitc-1
+board_upload.flash_size = 8MB
+board_build.partitions = default.csv
+build_flags=
+    -D TYPE_BW
+    -D CROWPANEL_ESP32S3_213
+    -D D_GDEH0213BN
+lib_deps =
+    ${common.lib_deps_builtin}
+    ${common.lib_deps}
+lib_ignore = ${common.lib_ignore}


### PR DESCRIPTION
- 5.79/4.2/2.13 boards definition
- fix to rotate 2.13 and report 250x122
- preserve behavior for other boards.