### PR TITLE
SVERIO_PAPERBOARD_SPI board configuration

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -144,7 +144,6 @@ lib_ignore = ${common.lib_ignore}
 [env:sverio_paperboard_spi]
 platform = espressif32
 board = esp32-s3-devkitc-1
-monitor_speed = 115200
 board_upload.flash_size = 16MB
 board_build.partitions = default.csv
 build_flags =

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -835,7 +835,6 @@ float getBatteryVoltage()
   adc1_config_channel_atten(vBatPin, ADC_ATTEN_DB_12);
 
   // Enable the measurement path via PMOS gate
-  pinMode(enableBattery, OUTPUT);
   digitalWrite(enableBattery, HIGH);
   delay(200);
 


### PR DESCRIPTION
Introduces the SVERIO_PAPERBOARD_SPI board configuration in firmware: SPI/I²C pin mapping, ePaper power handling, calibrated ADC battery measurement and initialization tweaks so the custom board boots cleanly and reports battery voltage accurately. 
Also adds a dedicated PlatformIO environment so it can be built with the correct ESP32-S3 target, flags, and dependencies. 