### PR TITLE
Add WiFi shutdown after last display page downloaded

### DIFF
--- a/src/display.cpp
+++ b/src/display.cpp
@@ -370,6 +370,11 @@ const char *getColorType()
   return defined_color_type;
 }
 
+uint16_t getNumberOfPages()
+{
+  return display.pages();
+}
+
 void initM5()
 {
 #ifdef M5StackCoreInk

--- a/src/display.h
+++ b/src/display.h
@@ -88,6 +88,7 @@ uint16_t getHeight();
 uint16_t getResolutionX();
 uint16_t getResolutionY();
 const char *getColorType();
+uint16_t getNumberOfPages();
 
 // M5Stack specific
 void initM5();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -107,6 +107,10 @@ void downloadAndDisplayImage(HttpClient &httpClient)
   // requests and downloads of one bitmap from server, since you have to always write whole image
   Display::setToFullWindow();
   Display::setToFirstPage();
+
+  // Store number of pages needed to fill the buffer of the display to turn off the WiFi after last page is loaded
+  uint16_t pagesToLoad = Display::getNumberOfPages();
+
   do
   {
     // For paged displays, download image once per page
@@ -115,6 +119,13 @@ void downloadAndDisplayImage(HttpClient &httpClient)
       break;
     }
     ImageHandler::readImageData(httpClient);
+
+    // turn of WiFi if no more pages left
+    if (--pagesToLoad == 0)
+    {
+      httpClient.stop();
+      Wireless::turnOff();
+    }
   } while (Display::setToNextPage());
 
   // Disable ePaper power

--- a/src/wireless.cpp
+++ b/src/wireless.cpp
@@ -99,4 +99,12 @@ bool isConnected()
 {
   return WiFi.status() == WL_CONNECTED;
 }
+
+void turnOff()
+{
+  WiFi.disconnect(true);
+  WiFi.mode(WIFI_OFF);
+  delay(20);
+  Serial.println("WiFi turned off");
+}
 } // namespace Wireless

--- a/src/wireless.h
+++ b/src/wireless.h
@@ -14,6 +14,7 @@ String getSoftAPSSID();
 String getSoftAPIP();
 
 bool isConnected();
+void turnOff();
 } // namespace Wireless
 
 #endif // WIRELESS_H


### PR DESCRIPTION
No need to keep Wi-Fi turned on after we write all pages to display buffer. Some displays are refreshing for dozens of seconds, so having Wi-Fi turned off could help a little with battery life.