### PR TITLE
Runtime compensation for sleep

### DIFF
--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -119,6 +119,11 @@ bool HttpClient::parseHeaders(bool checkTimestampOnly, uint64_t storedTimestamp)
       if (line.startsWith("SleepSeconds"))
       {
         m_sleepDuration = line.substring(14).toInt(); // already in seconds
+
+        // Deal with program runtime compensation (if not already set) for more accurate sleep time in seconds
+        if (StateManager::getProgramRuntimeCompensation() == 0)
+          StateManager::setProgramRuntimeCompensation(millis());
+
         Serial.print("SleepSeconds: ");
         Serial.println(m_sleepDuration);
       }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -185,8 +185,22 @@ void handleDisconnectedState()
 void enterDeepSleepMode()
 {
   uint64_t sleepDuration = StateManager::getSleepDuration();
+  // Calculate compensation and convert to seconds
+  unsigned long programRuntimeCompensation = (millis() - StateManager::getProgramRuntimeCompensation()) / 1000;
+
+  // Compensation is capped to max 60 seconds
+  if (programRuntimeCompensation > 60)
+    programRuntimeCompensation = 60;
+
+  if (programRuntimeCompensation < sleepDuration)
+    sleepDuration -= programRuntimeCompensation;
+
   Serial.print("Going to sleep for (seconds): ");
-  Serial.println(sleepDuration);
+  Serial.print(sleepDuration);
+  Serial.print(" (compensated by ");
+  Serial.print(programRuntimeCompensation);
+  Serial.println(" seconds)");
+
   Board::enterDeepSleepMode(sleepDuration);
 }
 

--- a/src/state_manager.cpp
+++ b/src/state_manager.cpp
@@ -8,10 +8,20 @@ namespace StateManager
 {
 
 uint64_t sleepDuration = DEFAULT_SLEEP_SECONDS;
+unsigned long programRuntimeCompensation = 0; // in milliseconds
 
 uint64_t getTimestamp() { return rtc_timestamp; }
 
 void setTimestamp(uint64_t ts) { rtc_timestamp = ts; }
+
+void setProgramRuntimeCompensation(unsigned long compensation)
+{
+  // Only set once if not already set
+  if (programRuntimeCompensation == 0)
+    programRuntimeCompensation = compensation;
+}
+
+unsigned long getProgramRuntimeCompensation() { return programRuntimeCompensation; }
 
 uint8_t getFailureCount() { return rtc_failureCount; }
 

--- a/src/state_manager.h
+++ b/src/state_manager.h
@@ -38,6 +38,10 @@ uint64_t getSleepDuration();
 void setSleepDuration(uint64_t seconds);
 uint64_t calculateSleepDuration();
 
+// Program runtime compensation
+void setProgramRuntimeCompensation(unsigned long compensation);
+unsigned long getProgramRuntimeCompensation();
+
 // Default sleep time
 static const uint64_t DEFAULT_SLEEP_SECONDS = 120;
 } // namespace StateManager


### PR DESCRIPTION
We should deduct number of seconds since receiving "SleepSec" header until display update is finished from Sleep time to be more accurate.