### PR TITLE
feat/streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,18 +36,19 @@ In code **board.h** do not forget to uncomment:
 1. Type of board used (ESPink_V2, ES3ink, ...)
 2. Select connection type (http/https) which will be used for contacting the server by using `-DUSE_CLIENT_HTTP`
 or `-DUSE_CLIENT_HTTPS` compiler flag. Default value is `https` variant.
-3. If you plan to connect one of the supported sensors via uŠup for reading temperature, humidity, and pressure/CO2 and sending the values to the server, uncomment in **sensor.h**
+3. **Streaming feature** is ENABLED by default for all ESP32 devices. This allows efficient buffering of image data in RAM before streaming to the display. To disable on resource-constrained devices, add `-D STREAMING_DISABLED` to your build_flags in **platformio.ini**
+4. If you plan to connect one of the supported sensors via uŠup for reading temperature, humidity, and pressure/CO2 and sending the values to the server, uncomment in **sensor.h**
 ```c
 // #define SENSOR
 ```
-4. Display type has to be changed in **display.h** In the case of GRAYSCALE, you must remove `zinggjm/GxEPD2` from **platformio.ini** (just comment it out), otherwise there will be a library collision and the code will not work. In that case, `lib/GxEPD2_4G` will be used. For other displays (BW, 3C, 7C), leave `zinggjm/GxEPD2` active, you don't need to do anything with the 4G version.
+5. Display type has to be changed in **display.h** In the case of GRAYSCALE, you must remove `zinggjm/GxEPD2` from **platformio.ini** (just comment it out), otherwise there will be a library collision and the code will not work. In that case, `lib/GxEPD2_4G` will be used. For other displays (BW, 3C, 7C), leave `zinggjm/GxEPD2` active, you don't need to do anything with the 4G version.
 ```c
 #define COLOR_TYPE=BW           // black and white
 // #define COLOR_TYPE=3C        // 3 colors - black, white and red/yellow
 // #define COLOR_TYPE=GRAYSCALE // grayscale - 4 colors
 // #define COLOR_TYPE=7C        // 7 colors
 ```
-5. Uncomment the definition of the specific ePaper you are putting into operation. This section begins at line `18`, and you need to select a specific display, e.g.:
+6. Uncomment the definition of the specific ePaper you are putting into operation. This section begins at line `18`, and you need to select a specific display, e.g.:
 ```c
 // BW
 // #define DISPLAY_TYPE=GDEY0213B7 // 122x250, 2.13"

--- a/src/image_handler.cpp
+++ b/src/image_handler.cpp
@@ -16,6 +16,7 @@
 
 #include "display.h"
 #include "state_manager.h"
+#include "streaming_handler.h"
 
 #ifdef TYPE_BW
   #include <GxEPD2_BW.h>
@@ -445,16 +446,46 @@ void readImageData(HttpClient &http)
   uint32_t startTime = millis();
   bool success = false;
 
+#ifdef STREAMING_ENABLED
+  // Initialize streaming if enabled
+  StreamingHandler::StreamingManager &streamMgr = StreamingHandler::StreamingManager::getInstance();
+  if (!streamMgr.isEnabled())
+  {
+    // Calculate row size: width * bytes_per_pixel (for most formats, 1 byte per pixel)
+    // For safety, use display width as row size estimate
+    size_t rowSize = Display::getWidth();
+
+    if (streamMgr.init(rowSize))
+      Serial.println("[Image] Streaming enabled");
+    else
+      Serial.println("[Image] Streaming init failed, falling back to direct mode");
+  }
+
+  // Print memory stats
+  if (streamMgr.isEnabled())
+  {
+    size_t totalHeap, freeHeap, bufferUsed;
+    streamMgr.getMemoryStats(totalHeap, freeHeap, bufferUsed);
+    Serial.printf("[Image] Memory - Total: %zu, Free: %zu, Buffer: %zu\n", totalHeap, freeHeap, bufferUsed);
+  }
+#endif
+
   // Read format header (2 bytes)
   uint16_t header = http.read16();
 
   Serial.print("Header: 0x");
   Serial.println(header, HEX);
 
-  // Allocate buffer on stack for this function call only
-  // Released automatically when function returns
-  static const uint16_t STREAM_BUFFER_SIZE = 512;
-  uint8_t buffer[STREAM_BUFFER_SIZE];
+  // Dynamic buffer for PNG/RLE processing
+  // BMP handles its own buffer allocation
+  const uint16_t STREAM_BUFFER_SIZE = 512;
+  uint8_t *buffer = new (std::nothrow) uint8_t[STREAM_BUFFER_SIZE];
+
+  if (!buffer)
+  {
+    Serial.println("[Image] Failed to allocate processing buffer");
+    return;
+  }
 
   // Route to appropriate format handler
   switch (static_cast<ImageFormat>(header))
@@ -482,6 +513,10 @@ void readImageData(HttpClient &http)
       break;
   }
 
+  // Cleanup processing buffer
+  delete[] buffer;
+  buffer = nullptr;
+
   // Handle errors
   if (!success)
   {
@@ -489,6 +524,12 @@ void readImageData(HttpClient &http)
     StateManager::setSleepDuration(StateManager::DEFAULT_SLEEP_SECONDS);
     StateManager::setTimestamp(0);
   }
+
+#ifdef STREAMING_ENABLED
+  // Cleanup streaming resources after processing
+  if (streamMgr.isEnabled())
+    streamMgr.cleanup();
+#endif
 }
 
 } // namespace ImageHandler

--- a/src/streaming_handler.cpp
+++ b/src/streaming_handler.cpp
@@ -1,0 +1,162 @@
+#include "streaming_handler.h"
+
+#include "utils.h"
+
+#ifdef STREAMING_ENABLED
+
+namespace StreamingHandler
+{
+
+// RowStreamBuffer Implementation
+RowStreamBuffer::RowStreamBuffer() : m_rowSize(0), m_rowCount(0), m_initialized(false) {}
+
+RowStreamBuffer::~RowStreamBuffer()
+{
+  m_buffer.clear();
+  m_buffer.shrink_to_fit();
+  m_rowWritePos.clear();
+  m_rowWritePos.shrink_to_fit();
+}
+
+bool RowStreamBuffer::init(size_t rowSizeBytes, size_t rowCount)
+{
+  if (m_initialized)
+  {
+    Serial.println("[Streaming] RowBuffer already initialized");
+    return true;
+  }
+
+  if (rowSizeBytes == 0 || rowSizeBytes > MAX_ROW_SIZE)
+  {
+    Serial.printf("[Streaming] Invalid row size: %zu (max: %zu)\n", rowSizeBytes, MAX_ROW_SIZE);
+    return false;
+  }
+
+  if (rowCount == 0)
+  {
+    Serial.println("[Streaming] Invalid row count: 0");
+    return false;
+  }
+
+  size_t totalSize = rowSizeBytes * rowCount;
+
+  // Check available heap
+  size_t freeHeap = Utils::getFreeHeap();
+  if (freeHeap < totalSize * 2)
+  {
+    Serial.printf("[Streaming] Insufficient heap: %zu bytes free, need %zu for row buffer\n", freeHeap, totalSize * 2);
+    return false;
+  }
+
+  try
+  {
+    m_buffer.resize(totalSize);
+    m_rowWritePos.resize(rowCount, 0);
+    m_rowSize = rowSizeBytes;
+    m_rowCount = rowCount;
+    m_initialized = true;
+    Serial.printf("[Streaming] Row buffer initialized: %zu bytes/row × %zu rows = %zu bytes total\n", rowSizeBytes,
+                  rowCount, totalSize);
+    return true;
+  }
+  catch (const std::bad_alloc &e)
+  {
+    Serial.printf("[Streaming] Row buffer allocation failed: %s\n", e.what());
+    return false;
+  }
+}
+
+size_t RowStreamBuffer::writeRow(size_t rowIndex, const uint8_t *data, size_t length)
+{
+  if (!m_initialized || !data || length == 0)
+    return 0;
+
+  if (rowIndex >= m_rowCount)
+  {
+    Serial.printf("[Streaming] Invalid row index: %zu (max: %zu)\n", rowIndex, m_rowCount - 1);
+    return 0;
+  }
+
+  // Calculate row offset
+  size_t rowOffset = rowIndex * m_rowSize;
+  size_t writePos = m_rowWritePos[rowIndex];
+
+  // Don't overflow this row's buffer
+  size_t available = m_rowSize - writePos;
+  size_t toWrite = (length > available) ? available : length;
+
+  if (toWrite > 0)
+  {
+    std::copy(data, data + toWrite, m_buffer.begin() + rowOffset + writePos);
+    m_rowWritePos[rowIndex] += toWrite;
+  }
+
+  return toWrite;
+}
+
+const uint8_t *RowStreamBuffer::getRowData(size_t rowIndex) const
+{
+  if (!m_initialized || rowIndex >= m_rowCount)
+    return nullptr;
+
+  size_t rowOffset = rowIndex * m_rowSize;
+  return m_buffer.data() + rowOffset;
+}
+
+void RowStreamBuffer::clear()
+{
+  if (m_initialized)
+  {
+    std::fill(m_rowWritePos.begin(), m_rowWritePos.end(), 0);
+    std::fill(m_buffer.begin(), m_buffer.end(), 0);
+  }
+}
+
+void RowStreamBuffer::resetRow(size_t rowIndex)
+{
+  if (m_initialized && rowIndex < m_rowCount)
+  {
+    m_rowWritePos[rowIndex] = 0;
+  }
+}
+
+// StreamingManager Implementation
+bool StreamingManager::init(size_t rowSizeBytes, size_t rowCount)
+{
+  if (m_enabled)
+  {
+    Serial.println("[Streaming] Manager already enabled");
+    return true;
+  }
+
+  if (!m_buffer.init(rowSizeBytes, rowCount))
+  {
+    Serial.println("[Streaming] Failed to initialize row buffer");
+    return false;
+  }
+
+  m_enabled = true;
+  Serial.println("[Streaming] Manager initialized successfully");
+  return true;
+}
+
+void StreamingManager::getMemoryStats(size_t &totalHeap, size_t &freeHeap, size_t &bufferUsed) const
+{
+  totalHeap = Utils::getTotalHeap();
+  freeHeap = Utils::getFreeHeap();
+  bufferUsed = m_enabled ? m_buffer.getTotalSize() : 0;
+}
+
+void StreamingManager::cleanup()
+{
+  if (m_enabled)
+  {
+    m_buffer.clear();
+    m_enabled = false;
+    Serial.println("[Streaming] Manager cleanup complete");
+  }
+}
+
+} // namespace StreamingHandler
+
+#endif // STREAMING_ENABLED

--- a/src/streaming_handler.h
+++ b/src/streaming_handler.h
@@ -1,0 +1,95 @@
+#ifndef STREAMING_HANDLER_H
+#define STREAMING_HANDLER_H
+
+// Streaming feature control - enabled by default
+#ifndef STREAMING_DISABLED
+  #define STREAMING_ENABLED
+#endif
+
+#ifdef STREAMING_ENABLED
+  #ifndef STREAMING_BUFFER_ROWS_COUNT
+    #define STREAMING_BUFFER_ROWS_COUNT 1 // Default: buffer 1 row at a time
+  #endif
+
+  #include <Arduino.h>
+  #include <cstdint>
+  #include <vector>
+
+namespace StreamingHandler
+{
+
+// Row buffer configuration
+constexpr size_t MAX_ROW_SIZE = 4096; // Maximum size for a single row (safety limit)
+
+// Row-based streaming buffer for direct display writing
+class RowStreamBuffer
+{
+public:
+  RowStreamBuffer();
+  ~RowStreamBuffer();
+
+  // Prevent copying
+  RowStreamBuffer(const RowStreamBuffer &) = delete;
+  RowStreamBuffer &operator=(const RowStreamBuffer &) = delete;
+
+  bool init(size_t rowSizeBytes, size_t rowCount);
+
+  size_t writeRow(size_t rowIndex, const uint8_t *data, size_t length);
+
+  const uint8_t *getRowData(size_t rowIndex) const;
+  size_t getRowSize() const { return m_rowSize; }
+  size_t getRowCount() const { return m_rowCount; }
+  size_t getTotalSize() const { return m_rowSize * m_rowCount; }
+
+  void clear();
+  void resetRow(size_t rowIndex);
+
+  bool isInitialized() const { return m_initialized; }
+
+private:
+  std::vector<uint8_t> m_buffer;
+  std::vector<size_t> m_rowWritePos;
+  size_t m_rowSize;
+  size_t m_rowCount;
+  bool m_initialized;
+};
+
+// Singleton manager for row streaming
+class StreamingManager
+{
+public:
+  static StreamingManager &getInstance()
+  {
+    static StreamingManager instance;
+    return instance;
+  }
+
+  bool init(size_t rowSizeBytes, size_t rowCount = STREAMING_BUFFER_ROWS_COUNT);
+
+  RowStreamBuffer *getBuffer() { return m_enabled ? &m_buffer : nullptr; }
+
+  void getMemoryStats(size_t &totalHeap, size_t &freeHeap, size_t &bufferUsed) const;
+
+  bool isEnabled() const { return m_enabled; }
+
+  void cleanup();
+
+  // Delete copy/move constructors for singleton
+  StreamingManager(const StreamingManager &) = delete;
+  StreamingManager &operator=(const StreamingManager &) = delete;
+  StreamingManager(StreamingManager &&) = delete;
+  StreamingManager &operator=(StreamingManager &&) = delete;
+
+private:
+  StreamingManager() : m_enabled(false) {}
+  ~StreamingManager() { cleanup(); }
+
+  RowStreamBuffer m_buffer;
+  bool m_enabled;
+};
+
+} // namespace StreamingHandler
+
+#endif // STREAMING_ENABLED
+
+#endif // STREAMING_HANDLER_H

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -12,6 +12,21 @@ static Preferences prefs;
 namespace Utils
 {
 
+size_t getTotalHeap() { return ESP.getHeapSize(); }
+
+size_t getFreeHeap() { return ESP.getFreeHeap(); }
+
+size_t getLargestFreeBlock() { return ESP.getMaxAllocHeap(); }
+
+void printMemoryStats()
+{
+  Serial.println("[Memory Stats]");
+  Serial.printf("  Total Heap:  %zu bytes\n", getTotalHeap());
+  Serial.printf("  Free Heap:   %zu bytes\n", getFreeHeap());
+  Serial.printf("  Largest Block: %zu bytes\n", getLargestFreeBlock());
+  Serial.printf("  Usage:       %.1f%%\n", 100.0 * (1.0 - (float)getFreeHeap() / (float)getTotalHeap()));
+}
+
 void initializeAPIKey()
 {
   prefs.begin("zivyobraz");

--- a/src/utils.h
+++ b/src/utils.h
@@ -12,11 +12,15 @@
 
 namespace Utils
 {
+// Memory statistics
+size_t getTotalHeap();
+size_t getFreeHeap();
+size_t getLargestFreeBlock();
+void printMemoryStats();
 
 // API key management (stored in NVS, survives power cycles)
 void initializeAPIKey();
 uint32_t getStoredAPIKey();
-
 } // namespace Utils
 
 #endif // UTILS_H


### PR DESCRIPTION
- switch to dynamic allocation for display buffers
  - use an old way of allocation without smart pointers as we have just one singleton and one ownership
    - easy to switch to new way
- enable direct image streaming into display's rows
  - keep it enabled by default, but add there an option `STREAMING_DISABLED` to disable it
  - added option to set how many rows should be written via `STREAMING_BUFFER_ROWS_COUNT`, default 1