### PR TITLE
Extra button on board - special actions available

### DIFF
--- a/src/board.h
+++ b/src/board.h
@@ -47,6 +47,7 @@
   #define PIN_SDA 42
   #define PIN_SCL 2
   #define PIN_ALERT 9
+  #define EXT_BUTTON 40
   // ESP32-S3 with PSRAM - large buffer for single-page rendering
   #define BOARD_MAX_PAGE_BUFFER_SIZE (200 * 1024)
 
@@ -61,6 +62,7 @@
   #define PIN_SPI_CLK 12
   #define PIN_SDA 42
   #define PIN_SCL 2
+  #define EXT_BUTTON 40
   #define vBatPin 9
   #define dividerRatio (1.7693877551f)
   // ESP32-S3 with PSRAM - large buffer for single-page rendering
@@ -231,6 +233,7 @@
   #define PIN_SPI_SS PIN_SS
   #define PIN_SDA 19
   #define PIN_SCL 20
+  #define EXT_BUTTON 3
   #define enableBattery 21
   #define vBatPin 1
   #define dividerRatio (2.0f)
@@ -275,6 +278,7 @@ void setEPaperPowerOn(bool on);
 void enterDeepSleepMode(uint64_t sleepDuration);
 
 float getBatteryVoltage();
+unsigned long checkButtonPressDuration();
 } // namespace Board
 
 #endif // BOARD_H

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -361,6 +361,30 @@ void init()
   display.setTextColor(GxEPD_BLACK); // black font
 }
 
+void clear()
+{
+  Serial.println("Clearing display...");
+
+  init();
+
+  // Enable power supply for ePaper
+  Board::setEPaperPowerOn(true);
+  delay(500);
+
+  setToFullWindow();
+  setToFirstPage();
+  do
+  {
+    display.fillRect(0, 0, DISPLAY_RESOLUTION_X, DISPLAY_RESOLUTION_Y, GxEPD_WHITE);
+  } while (setToNextPage());
+
+  delay(100);
+  // Disable power supply for ePaper
+  Board::setEPaperPowerOn(false);
+
+  Serial.println("done");
+}
+
 void setRotation(uint8_t rotation) { display.setRotation(rotation); }
 
 uint16_t getWidth() { return display.width(); }

--- a/src/display.h
+++ b/src/display.h
@@ -81,6 +81,7 @@
 namespace Display
 {
 void init();
+void clear();
 void setRotation(uint8_t rotation);
 
 // Display info

--- a/src/wireless.cpp
+++ b/src/wireless.cpp
@@ -93,4 +93,18 @@ void turnOff()
   delay(20);
   Serial.println("WiFi turned off");
 }
+
+void resetCredentialsAndReboot()
+{
+  // Disconnect WiFi
+  turnOff();
+
+  // Reset WiFi settings (erase stored credentials)
+  Serial.println("Erasing stored WiFi credentials...");
+  wm.resetSettings();
+
+  // Restart ESP to start configuration portal
+  Serial.println("Rebooting ESP...");
+  ESP.restart();
+}
 } // namespace Wireless

--- a/src/wireless.h
+++ b/src/wireless.h
@@ -15,6 +15,7 @@ String getSoftAPIP();
 
 bool isConnected();
 void turnOff();
+void resetCredentialsAndReboot();
 } // namespace Wireless
 
 #endif // WIRELESS_H


### PR DESCRIPTION
WIP :)

While adding the SeeedStudio reTerminal, I discovered that it has no reset button. However, there are three buttons connected to the board at the top of the device, and one labelled 'reset' is connected to GPIO3.

This suggests the possibility of operating the connected buttons. ESPInk 3.5 also has an additional button (as well as RESET).

I am trying to achieve the following button behaviour:
- Short press (less than 2 seconds): restart.
- Medium press (2–6 seconds): clears the screen to white. This is useful when we want to stop using the device for a while and store it, as this prevents any image remaining on the display, which can cause problems during long storage.
- Press for 6+ seconds: clears Wi-Fi settings.