### PR TITLE
Feat/http params

### DIFF
--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -38,6 +38,11 @@ bool HttpClient::sendRequest(bool timestampCheckOnly, const String &extraParams)
   url += "&fw=" + String(firmware);
   url += "&ap_retries=" + String(StateManager::getFailureCount());
   url += "&r=" + String(static_cast<uint8_t>(StateManager::getResetReason()));
+
+  // Add last compensation time if available from previous run
+  if (StateManager::getLastCompensationTime() > 0)
+    url += "&ct=" + String(StateManager::getLastCompensationTime());
+
   url += extraParams;
 
   Serial.print("Connecting to: ");
@@ -127,8 +132,8 @@ bool HttpClient::parseHeaders(bool checkTimestampOnly, uint64_t storedTimestamp)
         m_sleepDuration = line.substring(14).toInt();
 
         // Deal with program runtime compensation (if not already set) for more accurate sleep time in seconds
-        if (StateManager::getProgramRuntimeCompensation() == 0)
-          StateManager::setProgramRuntimeCompensation(millis());
+        if (StateManager::getProgramRuntimeCompensationStart() == 0)
+          StateManager::setProgramRuntimeCompensationStart(millis());
 
         Serial.print("Sleep in seconds: ");
         Serial.println(m_sleepDuration);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -187,10 +187,14 @@ void handleDisconnectedState()
 void enterDeepSleepMode()
 {
   uint64_t sleepDuration = StateManager::getSleepDuration();
-  // Calculate compensation and convert to seconds
-  unsigned long programRuntimeCompensation = (millis() - StateManager::getProgramRuntimeCompensation()) / 1000;
+  // Calculate compensation in milliseconds
+  unsigned long programRuntimeCompensationMs = millis() - StateManager::getProgramRuntimeCompensationStart();
 
-  // Compensation is capped to max 60 seconds
+  // Save compensation time in milliseconds for next run (survives deep sleep)
+  StateManager::setLastCompensationTime(programRuntimeCompensationMs);
+
+  // Convert to seconds for sleep duration adjustment, capped to max 60 seconds
+  unsigned long programRuntimeCompensation = programRuntimeCompensationMs / 1000;
   if (programRuntimeCompensation > 60)
     programRuntimeCompensation = 60;
 

--- a/src/state_manager.cpp
+++ b/src/state_manager.cpp
@@ -3,6 +3,7 @@
 // RTC persistent data (survives deep sleep)
 RTC_DATA_ATTR uint64_t rtc_timestamp = 0;
 RTC_DATA_ATTR uint8_t rtc_failureCount = 0;
+RTC_DATA_ATTR long rtc_lastCompensationTime = 0;
 
 namespace StateManager
 {
@@ -14,14 +15,18 @@ uint64_t getTimestamp() { return rtc_timestamp; }
 
 void setTimestamp(uint64_t ts) { rtc_timestamp = ts; }
 
-void setProgramRuntimeCompensation(unsigned long compensation)
+unsigned long getProgramRuntimeCompensationStart() { return programRuntimeCompensation; }
+
+void setProgramRuntimeCompensationStart(unsigned long compensation)
 {
   // Only set once if not already set
   if (programRuntimeCompensation == 0)
     programRuntimeCompensation = compensation;
 }
 
-unsigned long getProgramRuntimeCompensation() { return programRuntimeCompensation; }
+long getLastCompensationTime() { return rtc_lastCompensationTime; }
+
+void setLastCompensationTime(long time) { rtc_lastCompensationTime = time; }
 
 uint8_t getFailureCount() { return rtc_failureCount; }
 

--- a/src/state_manager.h
+++ b/src/state_manager.h
@@ -39,8 +39,12 @@ void setSleepDuration(uint64_t seconds);
 uint64_t calculateSleepDuration();
 
 // Program runtime compensation
-void setProgramRuntimeCompensation(unsigned long compensation);
-unsigned long getProgramRuntimeCompensation();
+unsigned long getProgramRuntimeCompensationStart();
+void setProgramRuntimeCompensationStart(unsigned long compensation);
+
+// Last runtime compensation time (in RTC memory to send as part of a report to server next run)
+long getLastCompensationTime();
+void setLastCompensationTime(long time);
 
 // Default sleep time
 static const uint64_t DEFAULT_SLEEP_SECONDS = 120;


### PR DESCRIPTION
Add more parameters for telemetry into HTTP GET:
- Reset type - What caused reset? Could be used on server for content-switch based on user triggered reset.
- Compensation time - Time needed to download content and refresh display combined. Time needed for display refresh is known (based on display type and refresh [full/fast] type).
- Detected sensor - What kind of sensor is connected to board.

Parameter names in GET are a little cryptic ('d' for display, 'ct' for compensation time, 's' for sensor) - we want to keep request length small, those letters are not used (well, there is only a few parameters). They are documented:
https://wiki.zivyobraz.eu/doku.php?id=portal:komunikace_se_serverem

Main goal here:
- Add more data for server to better serve requests and to better utilize board and display capabilities.
- More information for users.
- Gather more values that will be later used in JSON API.