### PR TITLE
(feat) Light sleep mode when display refresh

### DIFF
--- a/src/display.h
+++ b/src/display.h
@@ -224,6 +224,7 @@ void setToPartialWindow(int16_t xCord, int16_t yCord, int16_t width, int16_t hei
 bool supportsPartialRefresh();
 void setToFirstPage();
 bool setToNextPage();
+void enableLightSleepDuringRefresh(bool enable);
 
 // Error screens
 void showNoWiFiError(uint64_t sleepMinutes, const String &wikiUrl);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,8 +138,14 @@ void downloadAndDisplayImage(HttpClient &httpClient)
     {
       httpClient.stop();
       Wireless::turnOff();
+
+      // Enable light sleep during display refresh to save power
+      Display::enableLightSleepDuringRefresh(true);
     }
   } while (Display::setToNextPage());
+
+  // Disable light sleep callback after refresh completes
+  Display::enableLightSleepDuringRefresh(false);
 
   // Disable ePaper power
   delay(100);


### PR DESCRIPTION
This caught my eye:
https://github.com/bitbank2/bb_epaper/releases/tag/2.0.1

So I investigated a little why is light sleep beneficial - ESP32 takes much less power during light sleep and some displays refreshes for 10+ seconds, so it really makes sense to enter light sleep (wake-up latency just 1 ms).

Implementation is using GxEPD2 setBusyCallback, that's why I added functions for light sleep into Display rather than Board - they are tightly connected to display.epd2.