### PR TITLE
(feat) Direct stream into display buffer

### DIFF
--- a/src/display.h
+++ b/src/display.h
@@ -86,12 +86,12 @@
 ///////////////////////
 
 #ifdef COLOR_TYPE
-  // Define color type constants for comparison
-  #define CT_BW 1
+  // Define color type constants for comparison (matches PixelPacker::DisplayFormat)
+  #define CT_BW 0
+  #define CT_GRAYSCALE 1
   #define CT_3C 2
   #define CT_4C 3
-  #define CT_GRAYSCALE 4
-  #define CT_7C 5
+  #define CT_7C 4
 
 // Create COLOR_TYPE_STRING constant
 static constexpr const char COLOR_TYPE_STRING[] = XSTR(COLOR_TYPE);
@@ -226,6 +226,13 @@ bool supportsPartialRefresh();
 void setToFirstPage();
 bool setToNextPage();
 void enableLightSleepDuringRefresh(bool enable);
+
+// Direct streaming functions (for row-by-row streaming mode)
+bool supportsDirectStreaming();
+void initDirectStreaming(bool partialRefresh = false, uint16_t maxRowCount = 0);
+void writeRowsDirect(uint16_t yStart, uint16_t rowCount, const uint8_t *blackData, const uint8_t *colorData);
+void finishDirectStreaming();
+void refreshDisplay();
 
 // Error screens
 void showNoWiFiError(uint64_t sleepMinutes, const String &wikiUrl);

--- a/src/http_client.h
+++ b/src/http_client.h
@@ -26,9 +26,14 @@ public:
   HttpClient();
 
   // Check if server has new content
-  bool checkForUpdate(bool timestampCheck = true);
+  // If keepConnectionOpen is true and update is available, connection stays open for immediate image reading
+  bool checkForUpdate(bool timestampCheck = true, bool keepConnectionOpen = false);
+
+  // Check if image data is ready to be read (connection kept open after checkForUpdate)
+  bool hasImageDataReady() const { return m_imageDataReady; }
 
   // Start downloading image (call after checkForUpdate returns true)
+  // Not needed if checkForUpdate was called with keepConnectionOpen=true
   bool startImageDownload();
 
   // Connection status
@@ -69,6 +74,7 @@ private:
   uint8_t m_displayRotation;
   bool m_hasRotation;
   bool m_partialRefresh;
+  bool m_imageDataReady;
   String m_jsonPayload;
   JsonDocument m_jsonDoc;
 

--- a/src/image_handler.cpp
+++ b/src/image_handler.cpp
@@ -10,11 +10,16 @@
  * - Z1:  ZivyObraz RLE format (1 byte color + 1 byte count)
  * - Z2:  ZivyObraz RLE format (2-bit color + 6-bit count) - Most efficient
  * - Z3:  ZivyObraz RLE format (3-bit color + 5-bit count)
+ *
+ * Modes:
+ * - Paged mode: Traditional page-by-page drawing (backward compatible)
+ * - Direct streaming mode: Decode and write rows directly to display controller
  */
 
 #include "image_handler.h"
 
 #include "display.h"
+#include "pixel_packer.h"
 #include "logger.h"
 #include "state_manager.h"
 #include "streaming_handler.h"
@@ -116,6 +121,139 @@ static uint16_t mapColorValue(uint8_t pixelColor, uint16_t color2, uint16_t colo
       return GxEPD_WHITE;
   }
 }
+
+///////////////////////////////////////////////
+// Direct Streaming Context
+///////////////////////////////////////////////
+
+#if defined(STREAMING_ENABLED) && defined(STREAMING_DIRECT_MODE)
+
+// Context for direct streaming decode
+struct DirectStreamContext
+{
+  StreamingHandler::RowStreamBuffer *buffer;
+  uint16_t displayWidth;
+  uint16_t displayHeight;
+  uint16_t currentRow;       // Current absolute row being decoded
+  uint16_t bufferRowIndex;   // Index within the row buffer (0 to bufferRowCount-1)
+  uint16_t bufferRowCount;   // Number of rows in buffer
+  uint16_t firstRowInBuffer; // First absolute row number in current buffer
+  uint32_t pixelsProcessed;
+  bool initialized;
+};
+
+static DirectStreamContext g_directCtx = {nullptr, 0, 0, 0, 0, 0, 0, 0, false};
+
+// Flush completed rows from buffer to display
+static void flushCompletedRows()
+{
+  if (!g_directCtx.initialized || !g_directCtx.buffer)
+    return;
+
+  // Check if current row has any pixels written
+  uint16_t currentRowPixels = g_directCtx.buffer->getRowPixelCount(g_directCtx.bufferRowIndex);
+  if (currentRowPixels == 0 && g_directCtx.bufferRowIndex == 0)
+    return; // Nothing to flush
+
+  uint16_t rowsToFlush = g_directCtx.bufferRowIndex + 1;
+
+  // Get buffer data
+  const uint8_t *blackData = g_directCtx.buffer->getRowData(0);
+  const uint8_t *colorData = g_directCtx.buffer->getColorRowData(0);
+
+  // Write rows to display
+  Display::writeRowsDirect(g_directCtx.firstRowInBuffer, rowsToFlush, blackData, colorData);
+
+  Logger::log<Logger::Level::DEBUG, Logger::Topic::STREAM>("Flushed {} rows starting at y={}\n", rowsToFlush,
+                                                           g_directCtx.firstRowInBuffer);
+
+  // Reset buffer for next batch
+  for (uint16_t i = 0; i < g_directCtx.bufferRowCount; i++)
+  {
+    g_directCtx.buffer->resetRow(i);
+  }
+
+  // Reset buffer index, caller is responsible for updating firstRowInBuffer
+  g_directCtx.bufferRowIndex = 0;
+}
+
+// Write a single pixel in direct streaming mode
+static void directStreamPixel(uint16_t x, uint16_t y, uint16_t color)
+{
+  if (!g_directCtx.initialized || !g_directCtx.buffer)
+    return;
+
+  // Check if we've moved to a new row
+  if (y != g_directCtx.currentRow)
+  {
+    // Calculate what the buffer row index would be for this new row
+    uint16_t newBufferRowIndex = y - g_directCtx.firstRowInBuffer;
+
+    // Check if we need to flush the buffer (new row would exceed buffer capacity)
+    if (newBufferRowIndex >= g_directCtx.bufferRowCount)
+    {
+      flushCompletedRows();
+      // After flush, update firstRowInBuffer to the new row we're about to write
+      g_directCtx.firstRowInBuffer = y;
+      newBufferRowIndex = 0;
+    }
+
+    g_directCtx.currentRow = y;
+    g_directCtx.bufferRowIndex = newBufferRowIndex;
+  }
+
+  // Write pixel to buffer
+  g_directCtx.buffer->setPixel(g_directCtx.bufferRowIndex, x, color);
+  g_directCtx.pixelsProcessed++;
+}
+
+// Initialize direct streaming context
+static bool initDirectStreamContext()
+{
+  StreamingHandler::StreamingManager &streamMgr = StreamingHandler::StreamingManager::getInstance();
+
+  if (!streamMgr.isEnabled() || !streamMgr.isDirectMode())
+    return false;
+
+  g_directCtx.buffer = streamMgr.getBuffer();
+  g_directCtx.displayWidth = Display::getResolutionX();
+  g_directCtx.displayHeight = Display::getResolutionY();
+  g_directCtx.currentRow = 0;
+  g_directCtx.bufferRowIndex = 0;
+  g_directCtx.bufferRowCount = g_directCtx.buffer->getRowCount();
+  g_directCtx.firstRowInBuffer = 0;
+  g_directCtx.pixelsProcessed = 0;
+  g_directCtx.initialized = true;
+
+  return true;
+}
+
+// Finalize direct streaming (flush remaining rows)
+static void finalizeDirectStream()
+{
+  if (!g_directCtx.initialized)
+    return;
+
+  // Flush any remaining rows in buffer
+  // Check if we have any pixels processed in the current buffer batch
+  if (g_directCtx.currentRow >= g_directCtx.firstRowInBuffer)
+  {
+    flushCompletedRows();
+  }
+
+  // Log final statistics
+  uint32_t totalPixels = (uint32_t)g_directCtx.displayWidth * g_directCtx.displayHeight;
+  uint32_t expectedRows = g_directCtx.displayHeight;
+  uint32_t lastRowProcessed = g_directCtx.currentRow;
+
+  Logger::log<Logger::Level::DEBUG, Logger::Topic::STREAM>("Finalize: processed {}/{} pixels, last row={}/{}\n",
+                                                           g_directCtx.pixelsProcessed, totalPixels, lastRowProcessed,
+                                                           expectedRows - 1);
+
+  g_directCtx.initialized = false;
+}
+
+#endif // STREAMING_ENABLED && STREAMING_DIRECT_MODE
 
 ///////////////////////////////////////////////
 // PNG Image Processing
@@ -307,6 +445,287 @@ static bool processPNG(HttpClient &http, uint32_t startTime, uint8_t *buffer, ui
 
   return success;
 }
+
+///////////////////////////////////////////////
+// Direct Streaming Image Processing
+///////////////////////////////////////////////
+
+#if defined(STREAMING_ENABLED) && defined(STREAMING_DIRECT_MODE)
+
+// Convert RGBA to display color for direct streaming (same logic as pngleOnDraw)
+static uint16_t rgbaToDisplayColor(uint8_t r, uint8_t g, uint8_t b, uint8_t a)
+{
+  if (a == 0)
+    return GxEPD_WHITE; // Transparent = white
+
+  #if defined(TYPE_BW)
+  uint8_t gray = (r * 77 + g * 150 + b * 29) >> 8;
+  return (gray < 128) ? GxEPD_BLACK : GxEPD_WHITE;
+
+  #elif defined(TYPE_3C)
+  if (r > 128 && r > (g + 80) && r > (b + 80))
+    return GxEPD_RED;
+  uint8_t gray = (r * 77 + g * 150 + b * 29) >> 8;
+  return (gray < 128) ? GxEPD_BLACK : GxEPD_WHITE;
+
+  #elif defined(TYPE_4C)
+  if (r > 128 && g > 128 && b < 80)
+    return GxEPD_YELLOW;
+  if (r > 128 && r > (g + 80) && r > (b + 80))
+    return GxEPD_RED;
+  uint8_t gray = (r * 77 + g * 150 + b * 29) >> 8;
+  return (gray < 128) ? GxEPD_BLACK : GxEPD_WHITE;
+
+  #elif defined(TYPE_7C)
+  if (r > 200 && g > 80 && g < 180 && b < 80)
+    return GxEPD_ORANGE;
+  if (r > 128 && r > (g + 80) && r > (b + 80))
+    return GxEPD_RED;
+  if (r > 128 && g > 128 && b < 80)
+    return GxEPD_YELLOW;
+  if (g > 128 && g > (r + 80) && g > (b + 80))
+    return GxEPD_GREEN;
+  if (b > 128 && b > (r + 80) && b > (g + 80))
+    return GxEPD_BLUE;
+  uint8_t gray = (r * 77 + g * 150 + b * 29) >> 8;
+  return (gray < 128) ? GxEPD_BLACK : GxEPD_WHITE;
+
+  #elif defined(TYPE_GRAYSCALE)
+  uint8_t gray = (r * 77 + g * 150 + b * 29) >> 8;
+  return (gray < 64) ? GxEPD_BLACK : (gray < 128) ? GxEPD_DARKGREY : (gray < 192) ? GxEPD_LIGHTGREY : GxEPD_WHITE;
+
+  #else
+  uint8_t gray = (r * 77 + g * 150 + b * 29) >> 8;
+  return (gray < 128) ? GxEPD_BLACK : GxEPD_WHITE;
+  #endif
+}
+
+// Direct streaming PNG callback
+static void pngleOnDrawDirect(pngle_t *pngle, uint32_t x, uint32_t y, uint32_t w, uint32_t h, const uint8_t rgba[4])
+{
+  if (!g_directCtx.initialized)
+    return;
+
+  if (x >= g_directCtx.displayWidth || y >= g_directCtx.displayHeight)
+    return;
+
+  uint16_t color = rgbaToDisplayColor(rgba[0], rgba[1], rgba[2], rgba[3]);
+  directStreamPixel(x, y, color);
+
+  // Yield periodically
+  if (g_directCtx.pixelsProcessed % 1000 == 0)
+    yield();
+}
+
+static bool processPNGDirect(HttpClient &http, uint32_t startTime, uint8_t *buffer, uint16_t bufferSize)
+{
+  Logger::log<Logger::Level::INFO, Logger::Topic::IMAGE>("PNG Processing (direct streaming mode)\n");
+
+  if (!initDirectStreamContext())
+  {
+    Logger::log<Logger::Level::ERROR, Logger::Topic::IMAGE>("PNG Failed to init direct stream context\n");
+    return false;
+  }
+
+  pngle_t *pngle = pngle_new();
+  if (!pngle)
+  {
+    Logger::log<Logger::Level::ERROR, Logger::Topic::IMAGE>("PNG Failed to create decoder\n");
+    return false;
+  }
+
+  pngle_set_draw_callback(pngle, pngleOnDrawDirect);
+
+  // Reconstruct PNG signature
+  uint8_t pngSignature[8];
+  pngSignature[0] = 0x89;
+  pngSignature[1] = 0x50;
+
+  uint32_t sigBytesRead = http.readBytes(&pngSignature[2], 6);
+  if (sigBytesRead != 6)
+  {
+    printReadError(2 + sigBytesRead);
+    pngle_destroy(pngle);
+    return false;
+  }
+
+  int fed = pngle_feed(pngle, pngSignature, 8);
+  if (fed < 0)
+  {
+    Logger::log<Logger::Level::ERROR, Logger::Topic::IMAGE>("PNG Signature error: {}\n", pngle_error(pngle));
+    pngle_destroy(pngle);
+    return false;
+  }
+
+  uint32_t bytes_read = 8;
+  bool success = true;
+
+  while (http.isConnected() || http.available())
+  {
+    uint32_t chunkSize = http.readBytes(buffer, bufferSize);
+    if (chunkSize == 0)
+      break;
+
+    bytes_read += chunkSize;
+
+    fed = pngle_feed(pngle, buffer, chunkSize);
+    if (fed < 0)
+    {
+      Logger::log<Logger::Level::ERROR, Logger::Topic::IMAGE>("PNG Decode error: {}\n", pngle_error(pngle));
+      success = false;
+      break;
+    }
+
+    yield();
+  }
+
+  pngle_destroy(pngle);
+
+  // Validate that we received enough pixels before finalizing
+  uint32_t totalPixels = (uint32_t)g_directCtx.displayWidth * g_directCtx.displayHeight;
+  uint32_t processedPixels = g_directCtx.pixelsProcessed;
+
+  if (processedPixels < totalPixels)
+  {
+    // Calculate completion percentage
+    uint8_t completionPct = (processedPixels * 100) / totalPixels;
+    Logger::log<Logger::Level::WARNING, Logger::Topic::IMAGE>("PNG Incomplete: {}/{} pixels ({}%)\n", processedPixels,
+                                                              totalPixels, completionPct);
+
+    // Accept if 95%+ complete (some PNGs may have transparent edges)
+    if (completionPct < 95)
+    {
+      Logger::log<Logger::Level::ERROR, Logger::Topic::IMAGE>("PNG Image incomplete, aborting\n");
+      finalizeDirectStream(); // Still flush what we have to clean up
+      return false;
+    }
+    Logger::log<Logger::Level::INFO, Logger::Topic::IMAGE>("PNG Image is 95%+ complete, accepting as valid\n");
+  }
+
+  finalizeDirectStream();
+
+  if (success)
+  {
+    Logger::log<Logger::Level::INFO, Logger::Topic::HTTP>("Bytes read {}, pixels processed {}\n", bytes_read,
+                                                          g_directCtx.pixelsProcessed);
+    Logger::log<Logger::Level::INFO, Logger::Topic::HTTP>("Loaded in {} ms\n", millis() - startTime);
+  }
+
+  return success;
+}
+
+static bool processRLEDirect(HttpClient &http, uint32_t startTime, ImageFormat format, uint8_t *buffer,
+                             uint16_t bufferSize)
+{
+  Logger::log<Logger::Level::INFO, Logger::Topic::IMAGE>("Processing {} (direct streaming mode)\n",
+                                                         formatToString(format));
+
+  if (!initDirectStreamContext())
+  {
+    Logger::log<Logger::Level::ERROR, Logger::Topic::IMAGE>("Z-format Failed to init direct stream context\n");
+    return false;
+  }
+
+  uint32_t bytes_read = 2; // Already read header
+  uint16_t w = g_directCtx.displayWidth;
+  uint16_t h = g_directCtx.displayHeight;
+  uint32_t totalPixels = w * h;
+
+  uint16_t color2 = getSecondColor();
+  uint16_t color3 = getThirdColor();
+
+  uint16_t row = 0;
+  uint16_t col = 0;
+
+  uint32_t bufferPos = 0;
+  uint32_t bufferAvailable = 0;
+  bool bufferEmpty = true;
+
+  while (g_directCtx.pixelsProcessed < totalPixels)
+  {
+    // Refill buffer if needed
+    if (bufferEmpty || bufferPos >= bufferAvailable)
+    {
+      if (!http.isConnected() && !http.available())
+      {
+        if (g_directCtx.pixelsProcessed >= (totalPixels * 95 / 100))
+        {
+          Logger::log<Logger::Level::INFO, Logger::Topic::IMAGE>(
+            "Z-format Image is 95%+ complete, accepting as valid\n");
+          break;
+        }
+        Logger::log<Logger::Level::ERROR, Logger::Topic::IMAGE>("Z-format Incomplete: {}/{} pixels\n",
+                                                                g_directCtx.pixelsProcessed, totalPixels);
+        finalizeDirectStream();
+        return false;
+      }
+
+      uint32_t bytesRead = http.readBytes(buffer, bufferSize);
+      if (bytesRead == 0)
+        break;
+
+      bufferPos = 0;
+      bufferEmpty = false;
+      bytes_read += bytesRead;
+      bufferAvailable = bytesRead;
+    }
+
+    uint8_t pixelColor, count;
+
+    if (format == ImageFormat::Z1)
+    {
+      if (bufferPos + 1 >= bufferAvailable)
+      {
+        bufferEmpty = true;
+        continue;
+      }
+      pixelColor = buffer[bufferPos++];
+      count = buffer[bufferPos++];
+    }
+    else
+    {
+      uint8_t compressed = buffer[bufferPos++];
+
+      if (format == ImageFormat::Z2)
+      {
+        count = compressed & 0b00111111;
+        pixelColor = (compressed & 0b11000000) >> 6;
+      }
+      else // Z3
+      {
+        count = compressed & 0b00011111;
+        pixelColor = (compressed & 0b11100000) >> 5;
+      }
+    }
+
+    uint16_t color = mapColorValue(pixelColor, color2, color3);
+
+    // Draw pixels using direct streaming
+    for (uint8_t i = 0; i < count && g_directCtx.pixelsProcessed < totalPixels; i++)
+    {
+      directStreamPixel(col, row, color);
+
+      if (++col >= w)
+      {
+        col = 0;
+        row++;
+      }
+    }
+
+    if (g_directCtx.pixelsProcessed % 10000 == 0)
+      yield();
+  }
+
+  finalizeDirectStream();
+
+  Logger::log<Logger::Level::INFO, Logger::Topic::HTTP>("Bytes read {}, pixels processed {}\n", bytes_read,
+                                                        g_directCtx.pixelsProcessed);
+  Logger::log<Logger::Level::INFO, Logger::Topic::HTTP>("Loaded in {} ms\n", millis() - startTime);
+
+  return (g_directCtx.pixelsProcessed >= totalPixels * 95 / 100);
+}
+
+#endif // STREAMING_ENABLED && STREAMING_DIRECT_MODE
 
 ///////////////////////////////////////////////
 // Unified RLE Format Processing
@@ -517,6 +936,114 @@ void readImageData(HttpClient &http)
   // Cleanup streaming resources after processing
   if (streamMgr.isEnabled())
     streamMgr.cleanup();
+#endif
+}
+
+///////////////////////////////////////////////
+// Direct Streaming Public Interface
+///////////////////////////////////////////////
+
+bool isDirectStreamingAvailable()
+{
+#if defined(STREAMING_ENABLED) && defined(STREAMING_DIRECT_MODE)
+  bool displaySupport = Display::supportsDirectStreaming();
+  bool packerSupport = PixelPacker::supportsDirectStreaming();
+  Logger::log<Logger::Level::DEBUG, Logger::Topic::IMAGE>("Direct streaming check: display={}, packer={}\n",
+                                                          displaySupport, packerSupport);
+  return displaySupport && packerSupport;
+#else
+  Logger::log<Logger::Level::INFO, Logger::Topic::IMAGE>("Direct streaming disabled at compile time\n");
+  return false;
+#endif
+}
+
+bool readImageDataDirect(HttpClient &http)
+{
+#if defined(STREAMING_ENABLED) && defined(STREAMING_DIRECT_MODE)
+  if (!isDirectStreamingAvailable())
+  {
+    Logger::log<Logger::Level::WARNING, Logger::Topic::IMAGE>("Direct streaming not available, use paged mode\n");
+    return false;
+  }
+
+  uint32_t startTime = millis();
+  bool success = false;
+
+  // Initialize streaming manager in direct mode
+  StreamingHandler::StreamingManager &streamMgr = StreamingHandler::StreamingManager::getInstance();
+
+  if (!streamMgr.isEnabled())
+  {
+    uint16_t displayWidth = Display::getResolutionX();
+    if (!streamMgr.initDirect(displayWidth, STREAMING_BUFFER_ROWS_COUNT))
+    {
+      Logger::log<Logger::Level::ERROR, Logger::Topic::IMAGE>("Failed to initialize direct streaming\n");
+      return false;
+    }
+
+    size_t totalHeap, freeHeap, bufferUsed;
+    streamMgr.getMemoryStats(totalHeap, freeHeap, bufferUsed);
+    Logger::log<Logger::Level::DEBUG, Logger::Topic::IMAGE>("Direct streaming - Total: {}, Free: {}, Buffer: {}\n",
+                                                            totalHeap, freeHeap, bufferUsed);
+  }
+
+  // Read format header
+  uint16_t header = http.read16();
+  Logger::log<Logger::Level::INFO, Logger::Topic::IMAGE>("Header: 0x{} (direct mode)\n", String(header, HEX).c_str());
+
+  // Allocate processing buffer
+  const uint16_t STREAM_BUFFER_SIZE = 512;
+  uint8_t *buffer = new (std::nothrow) uint8_t[STREAM_BUFFER_SIZE];
+
+  if (!buffer)
+  {
+    Logger::log<Logger::Level::ERROR, Logger::Topic::IMAGE>("Failed to allocate processing buffer\n");
+    streamMgr.cleanup();
+    return false;
+  }
+
+  // Route to direct streaming format handlers
+  switch (static_cast<ImageFormat>(header))
+  {
+    case ImageFormat::PNG:
+      success = processPNGDirect(http, startTime, buffer, STREAM_BUFFER_SIZE);
+      break;
+
+    case ImageFormat::Z1:
+      success = processRLEDirect(http, startTime, ImageFormat::Z1, buffer, STREAM_BUFFER_SIZE);
+      break;
+
+    case ImageFormat::Z2:
+      success = processRLEDirect(http, startTime, ImageFormat::Z2, buffer, STREAM_BUFFER_SIZE);
+      break;
+
+    case ImageFormat::Z3:
+      success = processRLEDirect(http, startTime, ImageFormat::Z3, buffer, STREAM_BUFFER_SIZE);
+      break;
+
+    default:
+      Logger::log<Logger::Level::ERROR, Logger::Topic::IMAGE>("Unknown format header: 0x{}\n",
+                                                              String(header, HEX).c_str());
+      success = false;
+      break;
+  }
+
+  delete[] buffer;
+
+  if (!success)
+  {
+    Logger::log<Logger::Level::ERROR, Logger::Topic::IMAGE>("Direct streaming failed\n");
+    StateManager::setSleepDuration(StateManager::DEFAULT_SLEEP_SECONDS);
+    StateManager::setTimestamp(0);
+  }
+
+  streamMgr.cleanup();
+  return success;
+
+#else
+  // Direct streaming not compiled in
+  Logger::log<Logger::Level::INFO, Logger::Topic::IMAGE>("Direct streaming not enabled at compile time\n");
+  return false;
 #endif
 }
 

--- a/src/image_handler.h
+++ b/src/image_handler.h
@@ -5,8 +5,15 @@
 
 namespace ImageHandler
 {
-// Read image data from HTTP client
+// Read image data from HTTP client (paged mode - for backward compatibility)
 void readImageData(HttpClient &http);
+
+// Read image data with direct streaming to display controller
+// Returns true if direct streaming was used, false if fell back to paged mode
+bool readImageDataDirect(HttpClient &http);
+
+// Check if direct streaming mode is available
+bool isDirectStreamingAvailable();
 } // namespace ImageHandler
 
 #endif // IMAGE_HANDLER_H

--- a/src/pixel_packer.cpp
+++ b/src/pixel_packer.cpp
@@ -1,0 +1,238 @@
+#include "pixel_packer.h"
+
+namespace PixelPacker
+{
+
+size_t getRowBufferSize(uint16_t width, DisplayFormat format)
+{
+  switch (format)
+  {
+    case DisplayFormat::BW:
+      return (width + 7) / 8; // 1bpp: 8 pixels per byte
+    case DisplayFormat::GRAYSCALE:
+      return (width + 3) / 4; // 2bpp: 4 pixels per byte
+    case DisplayFormat::COLOR_3C:
+      return (width + 7) / 8; // 1bpp per plane (need 2 buffers)
+    case DisplayFormat::COLOR_4C:
+      return (width + 3) / 4; // 2bpp: 4 pixels per byte
+    case DisplayFormat::COLOR_7C:
+      return (width + 1) / 2; // 4bpp: 2 pixels per byte
+    default:
+      return (width + 7) / 8;
+  }
+}
+
+uint8_t getBitsPerPixel(DisplayFormat format)
+{
+  switch (format)
+  {
+    case DisplayFormat::BW:
+      return 1;
+    case DisplayFormat::GRAYSCALE:
+      return 2;
+    case DisplayFormat::COLOR_3C:
+      return 1; // Per plane
+    case DisplayFormat::COLOR_4C:
+      return 2;
+    case DisplayFormat::COLOR_7C:
+      return 4;
+    default:
+      return 1;
+  }
+}
+
+void packPixelBW(uint8_t *buffer, uint16_t x, bool isBlack)
+{
+  uint16_t byteIndex = x / 8;
+  uint8_t bitPosition = 7 - (x % 8); // MSB first
+
+  if (isBlack)
+  {
+    buffer[byteIndex] &= ~(1 << bitPosition); // Clear bit for black
+  }
+  else
+  {
+    buffer[byteIndex] |= (1 << bitPosition); // Set bit for white
+  }
+}
+
+void packPixel4G(uint8_t *buffer, uint16_t x, uint8_t grey)
+{
+  uint16_t byteIndex = x / 4;
+  uint8_t pixelInByte = x % 4;
+
+  // Convert 8-bit grey to 2-bit value (0-3)
+  uint8_t value = grey >> 6; // Top 2 bits
+
+  // Clear existing bits and set new value
+  // Pixel order: pixel 0 in bits 7-6, pixel 1 in bits 5-4, etc.
+  uint8_t shift = (3 - pixelInByte) * 2;
+  buffer[byteIndex] = (buffer[byteIndex] & ~(0x03 << shift)) | (value << shift);
+}
+
+void packPixel3C(uint8_t *blackBuffer, uint8_t *colorBuffer, uint16_t x, uint16_t color)
+{
+  uint16_t byteIndex = x / 8;
+  uint8_t bitPosition = 7 - (x % 8); // MSB first
+
+  // 3C encoding:
+  // WHITE:  black=1, color=1 (both bits set)
+  // BLACK:  black=0, color=1 (black bit cleared)
+  // RED/YELLOW: black=1, color=0 (color bit cleared)
+
+  switch (color)
+  {
+    case static_cast<uint16_t>(GxEPDColor::BLACK):
+      blackBuffer[byteIndex] &= ~(1 << bitPosition); // Clear black bit
+      colorBuffer[byteIndex] |= (1 << bitPosition);  // Set color bit
+      break;
+    case static_cast<uint16_t>(GxEPDColor::RED):
+    case static_cast<uint16_t>(GxEPDColor::YELLOW):
+      blackBuffer[byteIndex] |= (1 << bitPosition);  // Set black bit
+      colorBuffer[byteIndex] &= ~(1 << bitPosition); // Clear color bit
+      break;
+    default:                                        // WHITE and others
+      blackBuffer[byteIndex] |= (1 << bitPosition); // Set black bit
+      colorBuffer[byteIndex] |= (1 << bitPosition); // Set color bit
+      break;
+  }
+}
+
+void packPixel4C(uint8_t *buffer, uint16_t x, uint8_t color4)
+{
+  uint16_t byteIndex = x / 4;
+  uint8_t pixelInByte = x % 4;
+
+  // Pixel order: pixel 0 in bits 7-6, pixel 1 in bits 5-4, etc. (MSB first)
+  uint8_t shift = (3 - pixelInByte) * 2;
+  buffer[byteIndex] = (buffer[byteIndex] & ~(0x03 << shift)) | ((color4 & 0x03) << shift);
+}
+
+void packPixel7C(uint8_t *buffer, uint16_t x, uint8_t color7)
+{
+  uint16_t byteIndex = x / 2;
+
+  if (x & 1)
+    buffer[byteIndex] = (buffer[byteIndex] & 0xF0) | (color7 & 0x0F); // Odd pixel: low nibble
+  else
+    buffer[byteIndex] = (buffer[byteIndex] & 0x0F) | ((color7 & 0x0F) << 4); // Even pixel: high nibble
+}
+
+
+void convertGrayscaleToBW(const uint8_t *src2bpp, uint8_t *dst1bpp, uint16_t width, uint16_t rowCount)
+{
+  uint16_t srcBytesPerRow = (width + 3) / 4; // 2bpp = 4 pixels per byte
+  uint16_t dstBytesPerRow = (width + 7) / 8; // 1bpp = 8 pixels per byte
+
+  for (uint16_t row = 0; row < rowCount; row++)
+  {
+    const uint8_t *srcRow = src2bpp + row * srcBytesPerRow;
+    uint8_t *dstRow = dst1bpp + row * dstBytesPerRow;
+
+    for (uint16_t dstByte = 0; dstByte < dstBytesPerRow; dstByte++)
+    {
+      uint8_t outByte = 0;
+
+      for (uint8_t bit = 0; bit < 8; bit++)
+      {
+        uint16_t pixelIndex = dstByte * 8 + bit;
+        if (pixelIndex >= width)
+          break;
+
+        // Extract 2-bit grayscale value (0=black, 1=dark gray, 2=light gray, 3=white)
+        uint16_t srcByteIndex = pixelIndex / 4;
+        uint8_t srcBitOffset = (3 - (pixelIndex % 4)) * 2; // MSB first
+        uint8_t grayValue = (srcRow[srcByteIndex] >> srcBitOffset) & 0x03;
+
+        // Threshold: >= 2 becomes white (1), < 2 becomes black (0)
+        // In e-paper: 1 = white, 0 = black
+        if (grayValue >= 2)
+        {
+          outByte |= (0x80 >> bit); // Set bit for white
+        }
+      }
+      dstRow[dstByte] = outByte;
+    }
+  }
+}
+
+uint8_t gxepdTo4CColor(uint16_t color)
+{
+  switch (color)
+  {
+    case static_cast<uint16_t>(GxEPDColor::BLACK):
+      return 0;
+    case static_cast<uint16_t>(GxEPDColor::YELLOW):
+      return 2;
+    case static_cast<uint16_t>(GxEPDColor::RED):
+      return 3;
+    case static_cast<uint16_t>(GxEPDColor::WHITE):
+    default:
+      return 1;
+  }
+}
+
+uint8_t gxepdTo7CColor(uint16_t color)
+{
+  switch (color)
+  {
+    case static_cast<uint16_t>(GxEPDColor::BLACK):
+      return 0;
+    case static_cast<uint16_t>(GxEPDColor::WHITE):
+      return 1;
+    case static_cast<uint16_t>(GxEPDColor::GREEN):
+      return 2;
+    case static_cast<uint16_t>(GxEPDColor::BLUE):
+      return 3;
+    case static_cast<uint16_t>(GxEPDColor::RED):
+      return 4;
+    case static_cast<uint16_t>(GxEPDColor::YELLOW):
+      return 5;
+    case static_cast<uint16_t>(GxEPDColor::ORANGE):
+      return 6;
+    default:
+      return 1; // Default to white
+  }
+}
+
+uint8_t gxepdToGrey(uint16_t color)
+{
+  switch (color)
+  {
+    case static_cast<uint16_t>(GxEPDColor::BLACK):
+      return 0x00; // Black (2-bit: 00)
+    case static_cast<uint16_t>(GxEPDColor::DARKGREY):
+      return 0x40; // Dark grey (2-bit: 01)
+    case static_cast<uint16_t>(GxEPDColor::LIGHTGREY):
+      return 0x80; // Light grey (2-bit: 10)
+    case static_cast<uint16_t>(GxEPDColor::WHITE):
+      return 0xC0; // White (2-bit: 11)
+    default:
+      return 0xC0; // Default to white
+  }
+}
+
+void initRowBuffer(uint8_t *buffer, size_t size, DisplayFormat format)
+{
+  switch (format)
+  {
+    case DisplayFormat::BW:
+    case DisplayFormat::COLOR_3C:
+      memset(buffer, WHITE_BYTE_1BPP, size);
+      break;
+    case DisplayFormat::GRAYSCALE:
+      memset(buffer, WHITE_BYTE_2BPP, size);
+      break;
+    case DisplayFormat::COLOR_7C:
+      memset(buffer, WHITE_BYTE_4BPP, size);
+      break;
+    case DisplayFormat::COLOR_4C:
+      memset(buffer, WHITE_BYTE_4C, size);
+      break;
+    default:
+      memset(buffer, WHITE_BYTE_1BPP, size);
+      break;
+  }
+}
+
+} // namespace PixelPacker

--- a/src/pixel_packer.h
+++ b/src/pixel_packer.h
@@ -1,0 +1,65 @@
+#ifndef PIXEL_PACKER_H
+#define PIXEL_PACKER_H
+
+#include <Arduino.h>
+#include <cstdint>
+
+#include "display.h"
+
+namespace PixelPacker
+{
+
+// Display format types for streaming, values match CT_* defines from display.h
+enum class DisplayFormat : uint8_t
+{
+  BW = CT_BW,               // 1bpp black/white
+  GRAYSCALE = CT_GRAYSCALE, // 2bpp 4-level grayscale
+  COLOR_3C = CT_3C,         // Dual 1bpp planes (black + red/yellow)
+  COLOR_4C = CT_4C,         // 2bpp native
+  COLOR_7C = CT_7C          // 4bpp 7-color
+};
+
+// Color values in RGB565 format
+enum class GxEPDColor : uint16_t
+{
+  BLACK = 0x0000,    // R=0, G=0, B=0
+  WHITE = 0xFFFF,    // R=31, G=63, B=31
+  RED = 0xF800,      // R=31, G=0, B=0
+  YELLOW = 0xFFE0,   // R=31, G=63, B=0
+  GREEN = 0x07E0,    // R=0, G=63, B=0 (6E/7C displays only)
+  BLUE = 0x001F,     // R=0, G=0, B=31 (6E/7C displays only)
+  ORANGE = 0xFD20,   // R=31, G=41, B=0 (7C displays only)
+  DARKGREY = 0x7BEF, // R=15, G=31, B=15 (Grayscale displays)
+  LIGHTGREY = 0xC618 // R=24, G=48, B=24 (Grayscale displays)
+};
+
+// White byte patterns for buffer initialization
+constexpr uint8_t WHITE_BYTE_1BPP = 0xFF;
+constexpr uint8_t WHITE_BYTE_2BPP = 0xFF;
+constexpr uint8_t WHITE_BYTE_4BPP = 0x11;
+constexpr uint8_t WHITE_BYTE_4C = 0x55;
+
+inline constexpr DisplayFormat getDisplayFormat() { return static_cast<DisplayFormat>(COLOR_ID); }
+
+// All display types now support direct streaming including 4C, but leave this here until I test more displays
+inline constexpr bool supportsDirectStreaming() { return true; }
+
+size_t getRowBufferSize(uint16_t width, DisplayFormat format);
+uint8_t getBitsPerPixel(DisplayFormat format);
+
+void packPixelBW(uint8_t *buffer, uint16_t x, bool isBlack);
+void packPixel4G(uint8_t *buffer, uint16_t x, uint8_t grey);
+void packPixel3C(uint8_t *blackBuffer, uint8_t *colorBuffer, uint16_t x, uint16_t color);
+void packPixel4C(uint8_t *buffer, uint16_t x, uint8_t color4);
+void packPixel7C(uint8_t *buffer, uint16_t x, uint8_t color7);
+
+void convertGrayscaleToBW(const uint8_t *src2bpp, uint8_t *dst1bpp, uint16_t width, uint16_t rowCount);
+uint8_t gxepdToGrey(uint16_t color);
+uint8_t gxepdTo4CColor(uint16_t color);
+uint8_t gxepdTo7CColor(uint16_t color);
+
+void initRowBuffer(uint8_t *buffer, size_t size, DisplayFormat format);
+
+} // namespace PixelPacker
+
+#endif // PIXEL_PACKER_H

--- a/src/streaming_handler.h
+++ b/src/streaming_handler.h
@@ -6,20 +6,29 @@
   #define STREAMING_ENABLED
 #endif
 
+// Direct streaming mode - bypass paged output and write rows directly to display controller
+// Disable for 4C displays (not supported) or when paged mode is preferred
+#ifndef STREAMING_DIRECT_DISABLED
+  #define STREAMING_DIRECT_MODE
+#endif
+
 #ifdef STREAMING_ENABLED
   #ifndef STREAMING_BUFFER_ROWS_COUNT
-    #define STREAMING_BUFFER_ROWS_COUNT 1 // Default: buffer 1 row at a time
+    #define STREAMING_BUFFER_ROWS_COUNT 48 // Default row buffer size (will be reduced if heap is limited)
   #endif
 
   #include <Arduino.h>
   #include <cstdint>
+  #include <memory>
   #include <vector>
+
+  #include "pixel_packer.h"
 
 namespace StreamingHandler
 {
 
 // Row buffer configuration
-constexpr size_t MAX_ROW_SIZE = 4096; // Maximum size for a single row (safety limit)
+constexpr size_t MAX_ROW_SIZE = 1200; // Maximum size for a single row (safety limit)
 
 // Row-based streaming buffer for direct display writing
 class RowStreamBuffer
@@ -34,6 +43,9 @@ public:
 
   bool init(size_t rowSizeBytes, size_t rowCount);
 
+  // Initialize for direct streaming mode with display format
+  bool initDirect(uint16_t displayWidth, size_t rowCount, PixelPacker::DisplayFormat format);
+
   size_t writeRow(size_t rowIndex, const uint8_t *data, size_t length);
 
   const uint8_t *getRowData(size_t rowIndex) const;
@@ -41,17 +53,39 @@ public:
   size_t getRowCount() const { return m_rowCount; }
   size_t getTotalSize() const { return m_rowSize * m_rowCount; }
 
+  // Get secondary buffer for 3C color plane
+  const uint8_t *getColorRowData(size_t rowIndex) const;
+  uint8_t *getColorRowDataMutable(size_t rowIndex);
+
+  // Direct pixel packing methods
+  void setPixel(size_t rowIndex, uint16_t x, uint16_t color);
+  void setPixelGrey(size_t rowIndex, uint16_t x, uint8_t grey);
+
+  // Row management
+  void clearRow(size_t rowIndex);
+  bool isRowComplete(size_t rowIndex, uint16_t expectedPixels) const;
+  uint16_t getRowPixelCount(size_t rowIndex) const;
+  void incrementRowPixelCount(size_t rowIndex);
+
   void clear();
   void resetRow(size_t rowIndex);
 
   bool isInitialized() const { return m_initialized; }
+  bool isDirectMode() const { return m_directMode; }
+  PixelPacker::DisplayFormat getFormat() const { return m_format; }
+  uint16_t getDisplayWidth() const { return m_displayWidth; }
 
 private:
   std::vector<uint8_t> m_buffer;
+  std::vector<uint8_t> m_colorBuffer; // Secondary buffer for 3C color plane
   std::vector<size_t> m_rowWritePos;
+  std::vector<uint16_t> m_rowPixelCount; // Track pixels written per row
   size_t m_rowSize;
   size_t m_rowCount;
+  uint16_t m_displayWidth;
+  PixelPacker::DisplayFormat m_format;
   bool m_initialized;
+  bool m_directMode;
 };
 
 // Singleton manager for row streaming
@@ -66,11 +100,15 @@ public:
 
   bool init(size_t rowSizeBytes, size_t rowCount = STREAMING_BUFFER_ROWS_COUNT);
 
-  RowStreamBuffer *getBuffer() { return m_enabled ? &m_buffer : nullptr; }
+  // Initialize for direct streaming mode
+  bool initDirect(uint16_t displayWidth, size_t rowCount = STREAMING_BUFFER_ROWS_COUNT);
+
+  RowStreamBuffer *getBuffer() { return m_buffer.get(); }
 
   void getMemoryStats(size_t &totalHeap, size_t &freeHeap, size_t &bufferUsed) const;
 
-  bool isEnabled() const { return m_enabled; }
+  bool isEnabled() const { return m_buffer != nullptr; }
+  bool isDirectMode() const { return m_buffer && m_buffer->isDirectMode(); }
 
   void cleanup();
 
@@ -81,11 +119,10 @@ public:
   StreamingManager &operator=(StreamingManager &&) = delete;
 
 private:
-  StreamingManager() : m_enabled(false) {}
+  StreamingManager() = default;
   ~StreamingManager() { cleanup(); }
 
-  RowStreamBuffer m_buffer;
-  bool m_enabled;
+  std::unique_ptr<RowStreamBuffer> m_buffer;
 };
 
 } // namespace StreamingHandler


### PR DESCRIPTION
The main goal of this last important feature that I want to implement in version 3.0 is to write the rows of the image obtained from the server directly into the display buffer in the stream, so that we can omit the paged drawing and update the display in one run.

It would have been good to have this feature from the beginning, but you can't be perfect on the first try, right? :) Looking back, I realise that this has taken much more effort than I expected, but I do believe it's worth it.

There is still a paged drawing fallback that could be used in certain scenarios, so it's better to keep it for now. If we abandon it in the future, that's for another time.

There should be done much more testing and maybe I will find some bugs in certain scenarios, but it works just fine for few displays I'm testing for more than a week now, so please review the code, we might merge it as it is and next step for me will be more intensive testing on all setups I have before final 3.0 release.