### PR TITLE
(feat) Improv Wi-Fi provisioning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ In brief, about custom compilation and settings in the firmware code:
 You will need to have the following libraries installed:
 ```ini
 lib_deps =
-    zinggjm/GxEPD2@^1.6.0
+    zinggjm/GxEPD2@^1.6.5
+    jnthas/Improv WiFi Library@^0.0.4
     bblanchon/ArduinoJson@^7.2.1
     adafruit/Adafruit GFX Library@^1.11.9
     adafruit/Adafruit SHT4x Library@^1.0.5

--- a/platformio.ini
+++ b/platformio.ini
@@ -22,6 +22,7 @@ lib_deps_builtin =
     Wire
 lib_deps =
     zinggjm/GxEPD2@^1.6.5
+    jnthas/Improv WiFi Library@^0.0.4
     bblanchon/ArduinoJson@^7.2.1
     adafruit/Adafruit GFX Library@^1.11.9
     adafruit/Adafruit SHT4x Library@^1.0.5

--- a/scripts/generate_web_manifest.py
+++ b/scripts/generate_web_manifest.py
@@ -65,6 +65,7 @@ def generate_manifest(source, target, env):
         "name": fw_name,
         "version": fw_version,
         "new_install_prompt_erase": True,
+        "improv": True,
         "builds": [{"chipFamily": chip_family, "parts": parts_full}]
     }
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -561,12 +561,19 @@ void enableLightSleepDuringRefresh(bool enable)
   if (enable)
   {
     Logger::log<Logger::Level::DEBUG, Logger::Topic::DISP>("Enabling light sleep during display refresh\n");
-    display.epd2.setBusyCallback(busyCallbackLightSleep, nullptr);
+    setBusyCallback(busyCallbackLightSleep);
   }
   else
   {
-    display.epd2.setBusyCallback(nullptr, nullptr);
+    setBusyCallback(nullptr);
   }
+#endif
+}
+
+void setBusyCallback(void (*callback)(const void *))
+{
+#ifndef M5StackCoreInk
+  display.epd2.setBusyCallback(callback);
 #endif
 }
 

--- a/src/display.h
+++ b/src/display.h
@@ -230,6 +230,7 @@ bool supportsPartialRefresh();
 void setToFirstPage();
 bool setToNextPage();
 void enableLightSleepDuringRefresh(bool enable);
+void setBusyCallback(void (*callback)(const void *));
 
 // Direct streaming functions (for row-by-row streaming mode)
 bool supportsDirectStreaming();

--- a/src/improv_handler.cpp
+++ b/src/improv_handler.cpp
@@ -1,0 +1,94 @@
+#include "improv_handler.h"
+#include "board.h"
+#include "display.h"
+#include "logger.h"
+
+#include <Arduino.h>
+#include <ImprovWiFiLibrary.h>
+#include <WiFi.h>
+
+// External configuration
+extern const char *firmware;
+
+namespace ImprovHandler
+{
+
+static ImprovWiFi improvSerial(&Serial);
+static bool active = false;
+static bool initialized = false;
+
+static void onImprovWiFiConnected(const char *ssid, const char *password)
+{
+  Logger::log<Logger::Level::DEBUG, Logger::Topic::WIFI>("Improv: Credentials received, connecting...\n");
+
+  // Stop any existing WiFi connection (WiFiManager's AP)
+  WiFi.disconnect();
+  delay(100);
+
+  WiFi.mode(WIFI_STA);
+  WiFi.begin(ssid, password);
+
+  // Wait for connection with timeout
+  unsigned long startTime = millis();
+  constexpr unsigned long connectionTimeout = 15000; // 15 seconds
+
+  while (WiFi.status() != WL_CONNECTED && (millis() - startTime) < connectionTimeout)
+  {
+    delay(100);
+  }
+
+  if (WiFi.status() == WL_CONNECTED)
+  {
+    Logger::log<Logger::Level::INFO, Logger::Topic::WIFI>("Improv: WiFi connected successfully, restarting...\n");
+    delay(500);
+    ESP.restart();
+  }
+  else
+  {
+    Logger::log<Logger::Level::WARNING, Logger::Topic::WIFI>("Improv: WiFi connection failed\n");
+  }
+}
+
+void begin()
+{
+  if (active)
+    return;
+
+  // Initialize Improv only once
+  if (!initialized)
+  {
+    static String deviceName = String(Board::getBoardType()) + " + " + Display::getDisplayType();
+    improvSerial.setDeviceInfo(ImprovTypes::ChipFamily::CF_ESP32, "ZivyObraz.eu", firmware, deviceName.c_str(), "");
+    improvSerial.onImprovConnected(onImprovWiFiConnected);
+    initialized = true;
+  }
+
+  active = true;
+  Logger::log<Logger::Level::DEBUG, Logger::Topic::WIFI>("Improv: Handler started\n");
+}
+
+void loop()
+{
+  if (!active)
+    return;
+
+  // Process Improv serial data (non-blocking)
+  improvSerial.handleSerial();
+}
+
+void end()
+{
+  active = false;
+  Logger::log<Logger::Level::DEBUG, Logger::Topic::WIFI>("Improv: Handler stopped\n");
+}
+
+bool isActive() { return active; }
+
+void busyCallback(const void *)
+{
+  // Process Improv serial data during display busy wait
+  if (active)
+    improvSerial.handleSerial();
+}
+
+} // namespace ImprovHandler

--- a/src/improv_handler.h
+++ b/src/improv_handler.h
@@ -1,0 +1,15 @@
+#ifndef IMPROV_HANDLER_H
+#define IMPROV_HANDLER_H
+
+namespace ImprovHandler
+{
+
+void begin();
+void loop();
+void end();
+bool isActive();
+void busyCallback(const void *);
+
+} // namespace ImprovHandler
+
+#endif // IMPROV_HANDLER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,6 +29,7 @@
 #include "display.h"
 #include "http_client.h"
 #include "image_handler.h"
+#include "improv_handler.h"
 #include "logger.h"
 #include "state_manager.h"
 #include "streaming_handler.h"
@@ -49,6 +50,8 @@ const String urlWiki = "https://wiki.zivyobraz.eu";
 
 void configModeCallback()
 {
+  // Note: ImprovHandler::begin() is already called in Wireless::APCallback
+
   // Increment failure counter
   StateManager::incrementFailureCount();
 
@@ -58,7 +61,13 @@ void configModeCallback()
   // Show WiFi configuration screen on display only if ShowNoWifiError is enabled (default: 1)
   if (StateManager::getShowNoWifiError() == 1)
   {
+    // Set Improv busy callback so Improv processes serial data during display refresh
+    Display::setBusyCallback(ImprovHandler::busyCallback);
+
     Display::showWiFiError(Wireless::getSoftAPSSID(), wifiPassword, "http://" + Wireless::getSoftAPIP(), urlWiki);
+
+    // Clear busy callback after display refresh
+    Display::setBusyCallback(nullptr);
   }
   else
   {
@@ -76,6 +85,14 @@ void initializeWiFi()
   String hostname = "INK_" + Wireless::getMacAddress();
   hostname.replace(":", "");
   Wireless::init(hostname, wifiPassword, configModeCallback);
+
+  // In non-blocking mode, loop while config portal is active
+  // This allows both WiFiManager and Improv to process
+  while (Wireless::isConfigPortalActive() && !Wireless::isConnected())
+  {
+    Wireless::process();
+    delay(10);
+  }
 }
 
 void downloadAndDisplayImage(HttpClient &httpClient)

--- a/src/wireless.h
+++ b/src/wireless.h
@@ -6,6 +6,9 @@
 namespace Wireless
 {
 void init(const String &hostname, const String &password, void (*callback)());
+void process();
+bool isConfigPortalActive();
+
 String getSSID();
 int8_t getStrength();
 String getMacAddress();


### PR DESCRIPTION
Improv makes device installation really easy - you can set up a Wi-Fi connection right in the browser as soon as the firmware has been flashed.

Connecting to the device's AP, which can be difficult on some mobiles, is not necessary, but is still supported. The device continues to run an AP when no Wi-Fi is available. But with improv, you get streamlined experience: Flash, fill in form (on new clean installations) and you are ready to go:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/3dbc6249-b548-4a67-9341-e4e039a4f22b" />

Improv only runs when Wi-Fi connection setup is needed.

Not sure if we should release 3.1 because of this, but I want to make this available after PR goes through (and if you are OK with code, we can merge it) and will rebuild FW and enable Improv on web install after that.
