### PR TITLE
No PNG buffer when Z streaming is used

### DIFF
--- a/src/streaming_handler.h
+++ b/src/streaming_handler.h
@@ -44,7 +44,9 @@ public:
   bool init(size_t rowSizeBytes, size_t rowCount);
 
   // Initialize for direct streaming mode with display format
-  bool initDirect(uint16_t displayWidth, size_t rowCount, PixelPacker::DisplayFormat format);
+  // needsPngDecoder: if true, reserves ~40KB for PNG decoder + margin; if false, only minimal reserve
+  bool initDirect(uint16_t displayWidth, size_t rowCount, PixelPacker::DisplayFormat format,
+                  bool needsPngDecoder = true);
 
   size_t writeRow(size_t rowIndex, const uint8_t *data, size_t length);
 
@@ -108,7 +110,8 @@ public:
   bool init(size_t rowSizeBytes, size_t rowCount = STREAMING_BUFFER_ROWS_COUNT);
 
   // Initialize for direct streaming mode
-  bool initDirect(uint16_t displayWidth, size_t rowCount = STREAMING_BUFFER_ROWS_COUNT);
+  // needsPngDecoder: if true, reserves ~40KB for PNG decoder + margin; if false, only minimal reserve
+  bool initDirect(uint16_t displayWidth, size_t rowCount = STREAMING_BUFFER_ROWS_COUNT, bool needsPngDecoder = true);
 
   RowStreamBuffer *getBuffer() { return m_buffer.get(); }
 


### PR DESCRIPTION
It's one of the small enhancements that I've been pushing directly to main lately, but I'm not as focused as I'd like to be and I'd really appreciate another pair of eyes to check if it's OK 🙏. It's tested and works.

The idea is that we don't need to allocate about 40 KB of buffer for the PNG decoder when the format is not PNG. This will speed up image loading and provide more room for BW conversion when a grayscale display is used and a fast partial refresh is required.