### PR TITLE
Fix exitting while loop early when parsing HTTP headers

### DIFF
--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -158,7 +158,7 @@ bool HttpClient::parseHeaders(bool checkTimestampOnly, uint64_t storedTimestamp)
   m_otaRequired = false;
   m_otaUrl = "";
 
-  while (m_client.connected())
+  while (m_client.connected() || m_client.available())
   {
     String line = m_client.readStringUntil('\n');
 


### PR DESCRIPTION
With fast HTTP server (e.g. on local network) the `WifiClient.connected()` can report disconnection before all data is processed by the firmware. This fixes the `while` loop condition so all available data is processed even when the client reports it is no longer connected.

With the condition as-is the `parseHeaders` method returns `true` but with some (or all) HTTP response headers unprocessed and remaining in the buffer. Then they are misinterpreted as image header in `scanForImageHeader`.