### PR TITLE
Limit total time for scanning sensors on the bus

### DIFF
--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -87,6 +87,12 @@ SensorType Sensor::detectSensor()
 
   SensorType found = SensorType::NONE;
 
+  // One address check could take about 1 second instead of few ms, if there is no sensor or I2C issue
+  // so break the loop at SHTx scan in that case to avoid long boot times (and skip checking other sensors)
+  constexpr unsigned long SCAN_TIMEOUT_MS = 500;
+  const unsigned long scanStart = millis();
+  bool timeout = false;
+
   // Check for SHT40 OR SHT41 OR SHT45 (scan addresses)
   const uint8_t sht4xAddrs[] = {0x44, 0x45, 0x46};
   for (uint8_t addr : sht4xAddrs)
@@ -100,12 +106,20 @@ SensorType Sensor::detectSensor()
       found = SensorType::SHT4X;
       break;
     }
+
+    if (millis() - scanStart > SCAN_TIMEOUT_MS)
+    {
+      Logger::log<Logger::Topic::SENS>(
+        "Sensor scan timeout (>{} ms) during SHT4x scan, skipping remaining addresses and sensors\n", SCAN_TIMEOUT_MS);
+      timeout = true;
+      break;
+    }
   }
 
   // Got SHT4x?
-  if (found != SensorType::NONE)
+  if (found != SensorType::NONE || timeout)
   {
-    // Already found SHT4x, skip other sensors
+    // Already found SHT4x or timeout, skip other sensors
   }
   // Check for BME280
   else if (bme.begin())


### PR DESCRIPTION
I find out, that if there is no sensor connected to the board ESPInk v3.5 (and possibly others as well), there is like one second timeout when detecting sensor on the bus. So every first start (first boot/after reset) would take up to 7-8 seconds just to find out that there is no sensor connected. If anything is connected to I2C, it's very quick (like 10-20 ms).

I was trying a few different approaches in order to get this done in some quick scanning way, but after like 4 scenarios and lot of a research I could not affect this behavior. It's something low level.

So I added 500 ms scan timeout to help this scenario. 500 ms is nonsense for normal run - it would normally take under 10 ms to scan three SHT4x addreses. So if it take so much time here, I2C is not working and we can safely skip sensors scaning at this point.

This speeds up start in this scenario from 7 to under 1 second.