### PR TITLE
Power and CPU efficiency improvements

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -106,7 +106,7 @@ void enterDeepSleepMode(uint64_t sleepDuration)
   #if defined(EXT_BUTTON) && !defined(ESPink_V35)
   esp_sleep_enable_ext1_wakeup(1ULL << EXT_BUTTON, ESP_EXT1_WAKEUP_ANY_LOW);
   #endif
-  delay(100);
+  delay(10);
   esp_deep_sleep_start();
 #endif
 }

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -60,11 +60,11 @@ void setupHW()
   digitalWrite(enableBattery, LOW);
 #endif
 
-#ifdef CROWPANEL_ESP32S3_579
-  pinMode(ePaperPowerPin, OUTPUT);
+  // Power on ePaper early — sufficient time for stabilization passes
+  // during Display::init(), sensor init, WiFi connect, and HTTP before
+  // any actual display SPI transaction occurs
   setEPaperPowerOn(true);
   delay(50);
-#endif
 
   // Initialize display (epdiy boards set up I2C here via TPS65185 init)
   Display::init();
@@ -93,6 +93,9 @@ void setEPaperPowerOn(bool on)
 
 void enterDeepSleepMode(uint64_t sleepDuration)
 {
+  // Safety net: ensure ePaper power is off before deep sleep regardless of code path
+  setEPaperPowerOn(false);
+
   // Enter deep sleep
 #ifdef M5StackCoreInk
   Display::powerOffM5();
@@ -115,10 +118,7 @@ float getBatteryVoltage()
 #ifdef ESPink_V3
   Logger::log<Logger::Level::DEBUG, Logger::Topic::BATTERY>("Readingon ESPink V3 board\n");
 
-  setEPaperPowerOn(true);
   pinMode(PIN_ALERT, INPUT_PULLUP);
-
-  delay(100);
 
   Wire.begin(PIN_SDA, PIN_SCL);
 
@@ -146,8 +146,6 @@ float getBatteryVoltage()
 
   lipo.clearAlert();
   lipo.enableHibernate();
-
-  setEPaperPowerOn(false);
 
 #elif defined ES3ink
   esp_adc_cal_characteristics_t adc_cal;

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -282,7 +282,7 @@ float getBatteryVoltage()
   volt = (analogReadMilliVolts(vBatPin) * dividerRatio / 1000);
 #endif
 
-  Logger::log<Logger::Topic::BATTERY>("Voltage: {} V\n", volt);
+  Logger::log<Logger::Level::DEBUG, Logger::Topic::BATTERY>("Voltage: {} V\n", volt);
   return volt;
 }
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -426,35 +426,17 @@ void init()
   display.setTextColor(GxEPD_BLACK); // black font
 }
 
-void powerOnAndInit()
-{
-  // For REMAP_SPI boards: init SPI first
-#ifdef REMAP_SPI
-  init();
-  Board::setEPaperPowerOn(true);
-  delay(500);
-#else
-  Board::setEPaperPowerOn(true);
-  delay(500);
-  init();
-#endif
-}
-
 void clear()
 {
   Logger::log<Logger::Level::DEBUG, Logger::Topic::DISP>("Clearing display...\n");
 
-  powerOnAndInit();
+  init();
   setToFullWindow();
   setToFirstPage();
   do
   {
     display.fillRect(0, 0, DISPLAY_RESOLUTION_X, DISPLAY_RESOLUTION_Y, GxEPD_WHITE);
   } while (setToNextPage());
-
-  delay(100);
-  // Disable power supply for ePaper
-  Board::setEPaperPowerOn(false);
 
   Logger::log<Logger::Level::DEBUG, Logger::Topic::DISP>("Display cleared.\n");
 }
@@ -719,7 +701,7 @@ void refreshDisplay() { display.epd2.refresh(false); }
 
 void showNoWiFiError(uint64_t sleepSeconds, const String &wikiUrl)
 {
-  powerOnAndInit();
+  init();
   setToFullWindow();
   setToFirstPage();
   do
@@ -734,10 +716,6 @@ void showNoWiFiError(uint64_t sleepSeconds, const String &wikiUrl)
     display.setFont(&OpenSansSB_14px);
     centeredText("Docs: " + wikiUrl, DISPLAY_RESOLUTION_X / 2, DISPLAY_RESOLUTION_Y - 20);
   } while (setToNextPage());
-
-  delay(100);
-  // Disable power supply for ePaper
-  Board::setEPaperPowerOn(false);
 }
 
 void showWiFiError(const String &hostname, const String &password, const String &urlWeb, const String &wikiUrl)
@@ -752,7 +730,7 @@ void showWiFiError(const String &hostname, const String &password, const String 
 
   Board::DeviceInfo devInfo = Board::getDeviceInfo();
 
-  powerOnAndInit();
+  init();
   setToFullWindow();
   setToFirstPage();
   do
@@ -873,9 +851,5 @@ void showWiFiError(const String &hostname, const String &password, const String 
       drawQrCode(qrString.c_str(), 3, 93, small_resolution_x - 28, 3);
     }
   } while (setToNextPage());
-
-  delay(100);
-  // Disable power supply for ePaper
-  Board::setEPaperPowerOn(false);
 }
 } // namespace Display

--- a/src/display.h
+++ b/src/display.h
@@ -220,7 +220,6 @@ static constexpr const char DISPLAY_TYPE_STRING[] = XSTR(DISPLAY_TYPE);
 namespace Display
 {
 void init();
-void powerOnAndInit();
 void clear();
 void setRotation(uint8_t rotation);
 

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -125,10 +125,17 @@ bool HttpClient::sendRequest(bool timestampCheck)
   String url = "/index.php?timestampCheck=";
   url += timestampCheck ? "1" : "0";
 
-  m_client.print(String("POST ") + url + " HTTP/1.1\r\n" + "Host: " + host + "\r\n" +
-                 "X-API-Key: " + String(Utils::getStoredAPIKey()) + "\r\n" + "Content-Type: application/json\r\n" +
-                 "Content-Length: " + String(m_jsonPayload.length()) + "\r\n" + "Connection: close\r\n\r\n" +
-                 m_jsonPayload);
+  // Send HTTP request using multiple print() calls to avoid allocating one large heap String
+  m_client.print("POST ");
+  m_client.print(url);
+  m_client.print(" HTTP/1.1\r\nHost: ");
+  m_client.print(host);
+  m_client.print("\r\nX-API-Key: ");
+  m_client.print(Utils::getStoredAPIKey());
+  m_client.print("\r\nContent-Type: application/json\r\nContent-Length: ");
+  m_client.print(m_jsonPayload.length());
+  m_client.print("\r\nConnection: close\r\n\r\n");
+  m_client.print(m_jsonPayload);
 
   Logger::log<Logger::Topic::HTTP>("Request sent\n");
 

--- a/src/http_client.cpp
+++ b/src/http_client.cpp
@@ -116,10 +116,10 @@ bool HttpClient::sendRequest(bool timestampCheck)
   Logger::log<Logger::Level::DEBUG, Logger::Topic::HTTP>("Sending POST to: {}{}/index.php\n", CONNECTION_URL_PREFIX,
                                                          host);
 
-  // Pretty print JSON payload for debugging
+  // Pretty print JSON payload for device info
   String prettyJson;
   serializeJsonPretty(m_jsonDoc, prettyJson);
-  Logger::log<Logger::Level::DEBUG, Logger::Topic::HTTP>("JSON Payload:\n{}\n", prettyJson);
+  Logger::log<Logger::Level::INFO, Logger::Topic::HTTP>("JSON Payload:\n{}\n", prettyJson);
 
   // Build URL with timestampCheck query parameter
   String url = "/index.php?timestampCheck=";

--- a/src/image_handler.cpp
+++ b/src/image_handler.cpp
@@ -305,8 +305,9 @@ static void flushCompletedRows()
   Logger::log<Logger::Level::DEBUG, Logger::Topic::STREAM>("Flushed {} rows starting at y={}\n", rowsToFlush,
                                                            g_directCtx.firstRowInBuffer);
 
-  // Reset buffer for next batch
-  for (uint16_t i = 0; i < g_directCtx.bufferRowCount; i++)
+  // Reset buffer for next batch — only reset rows that were actually flushed,
+  // rows beyond rowsToFlush were never written in this batch and are already clean.
+  for (uint16_t i = 0; i < rowsToFlush; i++)
   {
     g_directCtx.buffer->resetRow(i);
   }

--- a/src/image_handler.cpp
+++ b/src/image_handler.cpp
@@ -346,6 +346,61 @@ static void directStreamPixel(uint16_t x, uint16_t y, uint16_t color)
   g_directCtx.pixelsProcessed++;
 }
 
+// Write a run of identical pixels in direct streaming mode.
+// Handles row boundaries and buffer flushing internally.
+// Much faster than calling directStreamPixel() per pixel for RLE formats.
+static void directStreamPixelRun(uint16_t &col, uint16_t &row, uint16_t count, uint16_t color)
+{
+  if (!g_directCtx.initialized || !g_directCtx.buffer || count == 0)
+    return;
+
+  const uint16_t w = g_directCtx.displayWidth;
+  const uint32_t totalPixels = (uint32_t)g_directCtx.displayWidth * g_directCtx.displayHeight;
+
+  while (count > 0 && g_directCtx.pixelsProcessed < totalPixels)
+  {
+    // Ensure buffer row index is up to date for the current absolute row
+    if (row != g_directCtx.currentRow)
+    {
+      uint16_t newBufferRowIndex = row - g_directCtx.firstRowInBuffer;
+
+      if (newBufferRowIndex >= g_directCtx.bufferRowCount)
+      {
+        flushCompletedRows();
+        g_directCtx.firstRowInBuffer = row;
+        newBufferRowIndex = 0;
+      }
+
+      g_directCtx.currentRow = row;
+      g_directCtx.bufferRowIndex = newBufferRowIndex;
+    }
+
+    // How many pixels can we write before hitting the row boundary?
+    uint16_t pixelsInRow = w - col;
+    uint16_t pixelsToWrite = (count < pixelsInRow) ? count : pixelsInRow;
+
+    // Also cap to remaining total pixels
+    uint32_t remainingTotal = totalPixels - g_directCtx.pixelsProcessed;
+    if (pixelsToWrite > remainingTotal)
+      pixelsToWrite = (uint16_t)remainingTotal;
+
+    if (pixelsToWrite == 0)
+      break;
+
+    // Bulk fill – replaces the per-pixel inner loop
+    g_directCtx.buffer->fillPixelRun(g_directCtx.bufferRowIndex, col, pixelsToWrite, color);
+    g_directCtx.pixelsProcessed += pixelsToWrite;
+    count -= pixelsToWrite;
+    col += pixelsToWrite;
+
+    if (col >= w)
+    {
+      col = 0;
+      row++;
+    }
+  }
+}
+
 // Initialize direct streaming context
 static bool initDirectStreamContext()
 {
@@ -762,17 +817,9 @@ static bool processRLEDirect(HttpClient &http, uint32_t startTime, ImageFormat f
 
     uint16_t color = mapColorValue(pixelColor, color2, color3);
 
-    // Draw pixels using direct streaming
-    for (uint8_t i = 0; i < count && g_directCtx.pixelsProcessed < totalPixels; i++)
-    {
-      directStreamPixel(col, row, color);
-
-      if (++col >= w)
-      {
-        col = 0;
-        row++;
-      }
-    }
+    // Write the entire RLE run in one bulk operation instead of pixel-by-pixel.
+    // directStreamPixelRun handles row boundaries and buffer flushes internally.
+    directStreamPixelRun(col, row, (uint16_t)count, color);
 
     if (g_directCtx.pixelsProcessed % 10000 == 0)
       yield();

--- a/src/logger.h
+++ b/src/logger.h
@@ -17,7 +17,7 @@ public:
 
 // Set minimum log level - messages below this level won't be compiled in
 #ifndef LOG_LEVEL_MINIMUM
-  static constexpr Level LOG_LEVEL_MINIMUM = Level::DEBUG; // Default: show all levels
+  static constexpr Level LOG_LEVEL_MINIMUM = Level::INFO; // Default: include INFO and above
 #endif
 
   enum class Topic : uint8_t

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -108,10 +108,6 @@ void initializeWiFi()
 
 void downloadAndDisplayImage(HttpClient &httpClient)
 {
-  // Enable ePaper power
-  Board::setEPaperPowerOn(true);
-  delay(500);
-
   // Start tracking download duration
   StateManager::startDownloadTimer();
 
@@ -241,10 +237,6 @@ void downloadAndDisplayImage(HttpClient &httpClient)
     // Disable light sleep callback after refresh completes
     Display::enableLightSleepDuringRefresh(false);
   }
-
-  // Disable ePaper power
-  delay(100);
-  Board::setEPaperPowerOn(false);
 
   // End refresh timing
   StateManager::endRefreshTimer();

--- a/src/pixel_packer.cpp
+++ b/src/pixel_packer.cpp
@@ -118,6 +118,165 @@ void packPixel7C(uint8_t *buffer, uint16_t x, uint8_t color7)
     buffer[byteIndex] = (buffer[byteIndex] & 0x0F) | ((color7 & 0x0F) << 4); // Even pixel: high nibble
 }
 
+// ---------------------------------------------------------------------------
+// Bulk fill functions – write a run of identical pixels using memset where
+// possible, which is much faster than per-pixel bit manipulation.
+// ---------------------------------------------------------------------------
+
+// BW (1bpp, 8 pixels/byte, MSB first): pixel x → bit (7 - x%8) in byte x/8
+void fillPixelRunBW(uint8_t *buffer, uint16_t startX, uint16_t count, bool isBlack)
+{
+  if (count == 0)
+    return;
+
+  const uint16_t endX = startX + count; // exclusive
+  const uint16_t startByte = startX >> 3u;
+  const uint16_t endByte = (uint16_t)((endX - 1u) >> 3u); // inclusive
+
+  // highBit = MSB position of first pixel, lowBit = MSB position of last pixel.
+  const uint8_t highBit = 7u - (uint8_t)(startX & 7u);
+  const uint8_t lowBit = 7u - (uint8_t)((endX - 1u) & 7u);
+
+  if (startByte == endByte)
+  {
+    // All pixels fit in one byte.
+    const uint8_t mask = (uint8_t)(((1u << (highBit - lowBit + 1u)) - 1u) << lowBit);
+    if (isBlack)
+      buffer[startByte] &= ~mask;
+    else
+      buffer[startByte] |= mask;
+    return;
+  }
+
+  // First partial byte: pixels startX ..(startByte+1)*8 - 1
+  {
+    const uint8_t mask = (uint8_t)((1u << (highBit + 1u)) - 1u); // bits 0..highBit
+    if (isBlack)
+      buffer[startByte] &= ~mask;
+    else
+      buffer[startByte] |= mask;
+  }
+
+  // Full middle bytes
+  if (endByte > startByte + 1u)
+    memset(buffer + startByte + 1u, isBlack ? 0x00 : 0xFF, endByte - startByte - 1u);
+
+  // Last partial byte: pixels endByte*8 .. endX-1
+  {
+    const uint8_t mask = (uint8_t)(0xFFu << lowBit); // bits lowBit..7
+    if (isBlack)
+      buffer[endByte] &= ~mask;
+    else
+      buffer[endByte] |= mask;
+  }
+}
+
+// 2bpp helper (4 pixels/byte, MSB first) used by GRAYSCALE and 4C fills
+using PackPixelFn = void (*)(uint8_t *, uint16_t, uint8_t);
+
+static void fillPixelRun2bpp(uint8_t *buffer, uint16_t startX, uint16_t count, uint8_t value, PackPixelFn packFn)
+{
+  if (count == 0)
+    return;
+
+  const uint8_t pattern = (uint8_t)((value << 6u) | (value << 4u) | (value << 2u) | value);
+  const uint16_t endX = startX + count;
+
+  const uint16_t startByte = startX / 4u;
+  const uint16_t endByte = (endX - 1u) / 4u;
+
+  if (startByte == endByte)
+  {
+    for (uint16_t x = startX; x < endX; x++)
+      packFn(buffer, x, value);
+    return;
+  }
+
+  // Leading partial pixels (up to the next 4-pixel aligned boundary)
+  const uint16_t firstFullPx = (startByte + 1u) * 4u;
+  for (uint16_t x = startX; x < firstFullPx; x++)
+    packFn(buffer, x, value);
+
+  // Full bytes in the middle
+  if (endByte > startByte + 1u)
+    memset(buffer + startByte + 1u, pattern, endByte - startByte - 1u);
+
+  // Trailing partial pixels
+  const uint16_t lastFullPx = endByte * 4u;
+  for (uint16_t x = lastFullPx; x < endX; x++)
+    packFn(buffer, x, value);
+}
+
+void fillPixelRunGrayscale(uint8_t *buffer, uint16_t startX, uint16_t count, uint8_t grey)
+{
+  fillPixelRun2bpp(buffer, startX, count, grey >> 6u, packPixel4G);
+}
+
+// 3C (dual 1bpp planes): delegate to fillPixelRunBW for each plane
+void fillPixelRun3C(uint8_t *blackBuffer, uint8_t *colorBuffer, uint16_t startX, uint16_t count, uint16_t color)
+{
+  if (count == 0)
+    return;
+
+  bool drawOnBlackPlane, drawOnColorPlane;
+  switch (color)
+  {
+    case static_cast<uint16_t>(GxEPDColor::BLACK):
+      drawOnBlackPlane = true;
+      drawOnColorPlane = false;
+      break;
+    case static_cast<uint16_t>(GxEPDColor::RED):
+    case static_cast<uint16_t>(GxEPDColor::YELLOW):
+      drawOnBlackPlane = false;
+      drawOnColorPlane = true;
+      break;
+    default: // WHITE and others
+      drawOnBlackPlane = false;
+      drawOnColorPlane = false;
+      break;
+  }
+  fillPixelRunBW(blackBuffer, startX, count, drawOnBlackPlane);
+  fillPixelRunBW(colorBuffer, startX, count, drawOnColorPlane);
+}
+
+// 4C (2bpp, 4 pixels/byte, MSB first): same layout as GRAYSCALE
+void fillPixelRun4C(uint8_t *buffer, uint16_t startX, uint16_t count, uint8_t color4)
+{
+  fillPixelRun2bpp(buffer, startX, count, color4 & 0x03, packPixel4C);
+}
+
+// 7C (4bpp, 2 pixels/byte): even pixel → high nibble, odd pixel → low nibble
+void fillPixelRun7C(uint8_t *buffer, uint16_t startX, uint16_t count, uint8_t color7)
+{
+  if (count == 0)
+    return;
+
+  const uint8_t c = color7 & 0x0Fu;
+  const uint8_t pattern = (uint8_t)((c << 4u) | c); // both nibbles
+  const uint16_t endX = startX + count;
+
+  uint16_t x = startX;
+
+  // Handle odd-aligned start: write single pixel into low nibble
+  if (x & 1u)
+  {
+    buffer[x / 2u] = (buffer[x / 2u] & 0xF0u) | c;
+    x++;
+  }
+
+  // Full bytes (even-aligned pairs)
+  const uint16_t fullBytes = (endX - x) / 2u;
+  if (fullBytes > 0u)
+  {
+    memset(buffer + x / 2u, pattern, fullBytes);
+    x += fullBytes * 2u;
+  }
+
+  // Trailing odd pixel: write into high nibble
+  if (x < endX)
+    buffer[x / 2u] = (buffer[x / 2u] & 0x0Fu) | (uint8_t)(c << 4u);
+}
+
 size_t convertGrayscaleToBW(uint8_t *buffer, uint16_t width, uint16_t rowCount)
 {
   uint16_t srcBytesPerRow = (width + 3) / 4; // 2bpp = 4 pixels per byte

--- a/src/pixel_packer.h
+++ b/src/pixel_packer.h
@@ -54,6 +54,14 @@ void packPixel3C(uint8_t *blackBuffer, uint8_t *colorBuffer, uint16_t x, uint16_
 void packPixel4C(uint8_t *buffer, uint16_t x, uint8_t color4);
 void packPixel7C(uint8_t *buffer, uint16_t x, uint8_t color7);
 
+// Bulk fill functions: write a run of identical pixels into a row buffer.
+// Much faster than calling packPixel* per pixel; uses memset for aligned sections.
+void fillPixelRunBW(uint8_t *buffer, uint16_t startX, uint16_t count, bool isBlack);
+void fillPixelRunGrayscale(uint8_t *buffer, uint16_t startX, uint16_t count, uint8_t grey);
+void fillPixelRun3C(uint8_t *blackBuffer, uint8_t *colorBuffer, uint16_t startX, uint16_t count, uint16_t color);
+void fillPixelRun4C(uint8_t *buffer, uint16_t startX, uint16_t count, uint8_t color4);
+void fillPixelRun7C(uint8_t *buffer, uint16_t startX, uint16_t count, uint8_t color7);
+
 size_t convertGrayscaleToBW(uint8_t *buffer, uint16_t width, uint16_t rowCount);
 uint8_t gxepdToGrey(uint16_t color);
 uint8_t gxepdTo4CColor(uint16_t color);

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -301,6 +301,9 @@ bool Sensor::readSTCC4(float &sen_temp, int &sen_humi, int &sen_pres)
     return false;
   }
 
+  // Put sensor to sleep to reduce power draw until deep sleep
+  stcc4.enterSleepMode();
+
   // Assign to output variables
   sen_temp = temp_temp;
   sen_humi = (int)temp_humidity;

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -222,8 +222,14 @@ bool Sensor::readSCD4X(float &sen_temp, int &sen_humi, int &sen_pres)
 
   SCD4.measureSingleShot();
 
+  unsigned long scd4xStart = millis();
   while (SCD4.readMeasurement() == false) // wait for a new data (approx 30s)
   {
+    if (millis() - scd4xStart > 60000)
+    {
+      Logger::log<Logger::Level::ERROR, Logger::Topic::SENS>("SCD4x measurement timed out\n");
+      return false;
+    }
     Logger::log<Logger::Topic::SENS>("Waiting for first measurement...\n");
     delay(1000);
   }

--- a/src/sensor.cpp
+++ b/src/sensor.cpp
@@ -68,12 +68,6 @@ void Sensor::init()
 
 SensorType Sensor::detectSensor()
 {
-  #if (defined ESPink_V2) || (defined ESPink_V3) || (defined ESPink_V35) || (defined ESP32S3Adapter)
-  // LaskaKit ESPink 2.5 needs to power up uSup
-  Board::setEPaperPowerOn(true);
-  delay(50);
-  #endif
-
   // End any previous Wire session to ensure clean state after deep sleep
   // epdiy uses the same I2C driver; do not delete it.
   #if !defined(SVERIO_PAPERBOARD_EPDIY)
@@ -132,11 +126,6 @@ SensorType Sensor::detectSensor()
     }
   }
 
-  #if (defined ESPink_V2) || (defined ESPink_V3) || (defined ESPink_V35) || (defined ESP32S3Adapter)
-  // Power down for now
-  Board::setEPaperPowerOn(false);
-  #endif
-
   return found;
 }
 
@@ -147,12 +136,6 @@ bool Sensor::readSensorsVal(float &sen_temp, int &sen_humi, int &sen_pres)
     Logger::log<Logger::Topic::SENS>("No sensor detected\n");
     return false;
   }
-
-  #if (defined ESPink_V2) || (defined ESPink_V3) || (defined ESPink_V35) || (defined ESP32S3Adapter)
-  // LaskaKit ESPink 2.5 needs to power up uSup
-  Board::setEPaperPowerOn(true);
-  delay(50);
-  #endif
 
   // End any previous Wire session to ensure clean state after deep sleep
   // epdiy uses the same I2C driver; do not delete it.
@@ -192,11 +175,6 @@ bool Sensor::readSensorsVal(float &sen_temp, int &sen_humi, int &sen_pres)
 
   if (!ret)
     Logger::log<Logger::Level::ERROR, Logger::Topic::SENS>("Failed to read sensor data\n");
-
-  #if (defined ESPink_V2) || (defined ESPink_V3) || (defined ESPink_V35) || (defined ESP32S3Adapter)
-  // Power down for now
-  Board::setEPaperPowerOn(false);
-  #endif
 
   return ret;
 }

--- a/src/streaming_handler.cpp
+++ b/src/streaming_handler.cpp
@@ -427,6 +427,52 @@ void RowStreamBuffer::setPixelGrey(size_t rowIndex, uint16_t x, uint8_t grey)
   incrementRowPixelCount(rowIndex);
 }
 
+void RowStreamBuffer::fillPixelRun(size_t rowIndex, uint16_t startX, uint16_t count, uint16_t color)
+{
+  if (!m_initialized || !m_directMode || rowIndex >= m_rowCount || count == 0)
+    return;
+  if (startX >= m_displayWidth)
+    return;
+
+  // Clip run to row width
+  if (startX + count > m_displayWidth)
+    count = m_displayWidth - startX;
+
+  size_t rowOffset = rowIndex * m_rowSize;
+  uint8_t *rowData = m_buffer.data() + rowOffset;
+
+  switch (m_format)
+  {
+    case PixelPacker::DisplayFormat::BW:
+      PixelPacker::fillPixelRunBW(rowData, startX, count, color == 0x0000u); // GxEPD_BLACK
+      break;
+
+    case PixelPacker::DisplayFormat::GRAYSCALE:
+      PixelPacker::fillPixelRunGrayscale(rowData, startX, count, PixelPacker::gxepdToGrey(color));
+      break;
+
+    case PixelPacker::DisplayFormat::COLOR_3C:
+    {
+      uint8_t *colorData = m_colorBuffer.data() + rowOffset;
+      PixelPacker::fillPixelRun3C(rowData, colorData, startX, count, color);
+    }
+    break;
+
+    case PixelPacker::DisplayFormat::COLOR_7C:
+      PixelPacker::fillPixelRun7C(rowData, startX, count, PixelPacker::gxepdTo7CColor(color));
+      break;
+
+    case PixelPacker::DisplayFormat::COLOR_4C:
+      PixelPacker::fillPixelRun4C(rowData, startX, count, PixelPacker::gxepdTo4CColor(color));
+      break;
+
+    default:
+      break;
+  }
+
+  m_rowPixelCount[rowIndex] += count;
+}
+
 void RowStreamBuffer::clearRow(size_t rowIndex)
 {
   if (!m_initialized || rowIndex >= m_rowCount)

--- a/src/streaming_handler.h
+++ b/src/streaming_handler.h
@@ -69,6 +69,9 @@ public:
   // Direct pixel packing methods
   void setPixel(size_t rowIndex, uint16_t x, uint16_t color);
   void setPixelGrey(size_t rowIndex, uint16_t x, uint8_t grey);
+  // Bulk fill: write a run of identical pixels starting at (rowIndex, startX).
+  // Significantly faster than calling setPixel per pixel for RLE formats.
+  void fillPixelRun(size_t rowIndex, uint16_t startX, uint16_t count, uint16_t color);
 
   // Row management
   void clearRow(size_t rowIndex);

--- a/src/wireless.cpp
+++ b/src/wireless.cpp
@@ -273,7 +273,7 @@ String getSSID()
 int8_t getStrength()
 {
   int8_t rssi = WiFi.RSSI();
-  Logger::log<Logger::Topic::WIFI>("Strength: {} dB\n", rssi);
+  Logger::log<Logger::Level::DEBUG, Logger::Topic::WIFI>("Strength: {} dB\n", rssi);
   return rssi;
 }
 


### PR DESCRIPTION
Thanks to Chiptron.cz and the profiler he lent me, I was able to analyze the energy consumption and figure out how to improve it.

The commits contain a number of mostly minor changes, except for sending pixels in batches—that took quite a bit of work, but it also shaved off about 100 ms of run and helped.

What helped the most was turning on the display and the bus right at board startup—the power consumption there is negligible, but we were able to get rid of a lot of code and, most importantly, the waiting, which isn’t necessary because it happens naturally :)